### PR TITLE
chore: fix dev shell in nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -79,7 +79,7 @@
               wayland-scanner
             ];
 
-            inherit (self.packages.${system}) buildInputs;
+            inherit (self.packages.${system}.default) buildInputs;
           };
         }
       );


### PR DESCRIPTION
small fix so that `nix develop` will work