### PR TITLE
chore: flake updates

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,19 @@
 {
   "nodes": {
+    "flake-compat": {
+      "locked": {
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "revCount": 69,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.1.0/01948eb7-9cba-704f-bbf3-3fa956735b52/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1743583204,
@@ -18,6 +32,7 @@
     },
     "root": {
       "inputs": {
+        "flake-compat": "flake-compat",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/shell.nix
+++ b/shell.nix
@@ -1,50 +1,13 @@
-# shell.nix
-
-with (import <nixpkgs> { });
-
-let
-  libPath =
-    with pkgs;
-    lib.makeLibraryPath [
-      #You can load external libraries that you need in your rust project here
-    ];
-  moz_overlay = import (builtins.fetchTarball "https://github.com/mozilla/nixpkgs-mozilla/archive/master.tar.gz");
-
-  nixpkgs = import <nixpkgs> {
-    overlays = [
-      moz_overlay
-    ];
-  };
-
-in
-mkShell {
-  name = "moz_overlay_shell";
-  buildInputs = [
-    # Compilers
-    clang
-
-    # Libs
-    cairo
-    pango
-    libxkbcommon
-    stdenv
-    glib
-    pipewire
-    wayland
-	  pkg-config
-    nixpkgs.latest.rustChannels.nightly.rust
-  ];
-  LD_LIBRARY_PATH = libPath;
-  RUST_BACKTRACE = 1;
-  shellHook = ''
-    export RUST_SRC_PATH="${nixpkgs.latest.rustChannels.nightly.rust-src}/lib/rustlib/src/rust/library"
-    export LIBCLANG_PATH="${pkgs.libclang.lib}/lib"
-  '';
-  BINDGEN_EXTRA_CLANG_ARGS =
-    (builtins.map (a: ''-I"${a}/include"'') [
-      # Add include paths for other libraries here
-    ])
-    ++ [
-      # Special directories
-    ];
-}
+(import
+  (
+    let
+      lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+      nodeName = lock.nodes.root.inputs.flake-compat;
+    in
+    fetchTarball {
+      url = lock.nodes.${nodeName}.locked.url or "https://github.com/edolstra/flake-compat/archive/${lock.nodes.${nodeName}.locked.rev}.tar.gz";
+      sha256 = lock.nodes.${nodeName}.locked.narHash;
+    }
+  )
+  { src = ./.; }
+).shellNix


### PR DESCRIPTION
`strictDeps = true;` validates for regressions by not adding `buildInputs` and equivalent to PATH, since tools should not be added to that list. Without cross-compilation and `strictDeps = true;`, there is no practical difference, but this keeps up good practices