### PR TITLE
fix flake issues

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
   outputs = { self, nixpkgs, ... }:
     let
       # System types to support.
-      targetSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      targetSystems = [ "x86_64-linux" "aarch64-linux" ];
 
       # Helper function to generate an attrset '{ x86_64-linux = f "x86_64-linux"; ... }'.
       forAllSystems = nixpkgs.lib.genAttrs targetSystems;

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
           # rustPlatform.buildRustPackage is not used because we build with Meson+Ninja
           default = pkgs.stdenv.mkDerivation rec {
             pname = "xdg-desktop-portal-luminous";
-            version = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package.version;
+            version = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).workspace.package.version;
 
             src = ./.;
 


### PR DESCRIPTION
regression happened in 7b889afcad49f1b10d6ae95126da763c724f4114

test with

```
nix flake check github:waycrate/xdg-desktop-portal-luminous
# evaluation fails
nix flake check github:axelkar/xdg-desktop-portal-luminous/patch-1 --all-systems
# works
```