### PR TITLE
Fix absolute pointer motions

### DIFF
--- a/src/remotedesktop/state.rs
+++ b/src/remotedesktop/state.rs
@@ -17,17 +17,23 @@ pub struct AppData {
     pub(crate) virtual_keyboard: ZwpVirtualKeyboardV1,
     pub(crate) virtual_pointer: ZwlrVirtualPointerV1,
     pub(crate) mods: u32,
+    output_width: u32,
+    output_height: u32,
 }
 
 impl AppData {
     pub fn new(
         virtual_keyboard: ZwpVirtualKeyboardV1,
         virtual_pointer: ZwlrVirtualPointerV1,
+        output_width: u32,
+        output_height: u32,
     ) -> Self {
         Self {
             virtual_keyboard,
             virtual_pointer,
             mods: Modifiers::empty().bits(),
+            output_width,
+            output_height,
         }
     }
 }
@@ -83,9 +89,14 @@ impl AppData {
         self.virtual_pointer.motion(10, dx, dy);
     }
 
-    pub fn notify_pointer_motion_absolute(&self, x: f64, y: f64, x_extent: u32, y_extent: u32) {
-        self.virtual_pointer
-            .motion_absolute(10, x as u32, y as u32, x_extent, y_extent);
+    pub fn notify_pointer_motion_absolute(&self, x: f64, y: f64) {
+        self.virtual_pointer.motion_absolute(
+            10,
+            x as u32,
+            y as u32,
+            self.output_width,
+            self.output_height,
+        );
     }
 
     pub fn notify_pointer_button(&self, button: i32, state: u32) {


### PR DESCRIPTION
This PR addresses issue #82.

`x_extent` and `y_extent` parameters are used for scaling purposes by the `notify_pointer_motion_absolute` method of `ZwlrVirtualPointerV1`([see here](https://github.com/swaywm/wlroots/blob/51f8c22f4d72f9e18657baccfff3db544c1c0660/types/wlr_virtual_pointer_v1.c#L64-L69)); therefore, they shouldn't be hardcoded.

The information about `WlOutput` size could be kept either in `RemoteDesktopBackend` or `AppData` struct. I chose the second option since `RemoteDesktopBackend`, as all the other interface backends, only implements a D-Bus interface and doesn't have state. Moreover, the need for this information is due to the specific method used by `AppData` to notify the cursor position, so I thought it makes sense to keep it there. This approach also allows not to expose this implementation detail in the `KeyOrPointerRequest` enum.
