### PR TITLE
Add keysyms management

### DIFF
--- a/src/remotedesktop/state.rs
+++ b/src/remotedesktop/state.rs
@@ -8,15 +8,17 @@ use wayland_client::{
 use wayland_protocols_wlr::virtual_pointer::v1::client::zwlr_virtual_pointer_v1::ZwlrVirtualPointerV1;
 
 use enumflags2::{BitFlag, BitFlags, bitflags};
-
 use thiserror::Error;
+use xkbcommon::xkb::{Context, Keymap, State};
 // This struct represents the state of our app. This simple app does not
 // need any state, by this type still supports the `Dispatch` implementations.
-#[derive(Debug)]
 pub struct AppData {
     pub(crate) virtual_keyboard: ZwpVirtualKeyboardV1,
     pub(crate) virtual_pointer: ZwlrVirtualPointerV1,
     pub(crate) mods: u32,
+    pub(crate) xkb_context: Context,
+    pub(crate) xkb_keymap: Keymap,
+    pub(crate) xkb_state: State,
     output_width: u32,
     output_height: u32,
 }
@@ -25,6 +27,9 @@ impl AppData {
     pub fn new(
         virtual_keyboard: ZwpVirtualKeyboardV1,
         virtual_pointer: ZwlrVirtualPointerV1,
+        xkb_context: Context,
+        xkb_keymap: Keymap,
+        xkb_state: State,
         output_width: u32,
         output_height: u32,
     ) -> Self {
@@ -32,6 +37,9 @@ impl AppData {
             virtual_keyboard,
             virtual_pointer,
             mods: Modifiers::empty().bits(),
+            xkb_context,
+            xkb_keymap,
+            xkb_state,
             output_width,
             output_height,
         }

--- a/src/remotedesktop/state.rs
+++ b/src/remotedesktop/state.rs
@@ -9,7 +9,10 @@ use wayland_protocols_wlr::virtual_pointer::v1::client::zwlr_virtual_pointer_v1:
 
 use enumflags2::{BitFlag, BitFlags, bitflags};
 use thiserror::Error;
-use xkbcommon::xkb::{Context, Keymap, State};
+use xkbcommon::xkb::{Context, Keycode, Keymap, Keysym, STATE_LAYOUT_EFFECTIVE, State};
+
+const LEFT_SHIFT: i32 = 42;
+const ALTGR: i32 = 100;
 // This struct represents the state of our app. This simple app does not
 // need any state, by this type still supports the `Dispatch` implementations.
 pub struct AppData {
@@ -83,14 +86,34 @@ impl AppData {
     // Keycode mappings as can be found in the file `/usr/include/linux/input-event-codes.h`.
     fn get_modifier_from_keycode(&self, keycode: i32) -> Option<Modifiers> {
         match keycode {
-            42 | 54 => Some(Modifiers::Shift), // left and right Shift
+            LEFT_SHIFT | 54 => Some(Modifiers::Shift), // left and right Shift
             58 => Some(Modifiers::CapsLock),
             29 | 97 => Some(Modifiers::Ctrl), // left and right Ctrl
             56 => Some(Modifiers::Alt),
             125 | 126 => Some(Modifiers::Super), // left and right Super
-            100 => Some(Modifiers::AltGr),
+            ALTGR => Some(Modifiers::AltGr),
             _ => None,
         }
+    }
+
+    fn get_keycode_from_keysym(&self, keysym: Keysym) -> Option<(u32, u32)> {
+        const EVDEV_OFFSET: u32 = 8;
+        let layout = self.xkb_state.serialize_layout(STATE_LAYOUT_EFFECTIVE);
+        let max_keycode = self.xkb_keymap.max_keycode();
+        for keycode in (self.xkb_keymap.min_keycode().raw()..max_keycode.raw()).map(Keycode::new) {
+            let n_levels = self.xkb_keymap.num_levels_for_key(keycode, layout);
+            for level in 0..n_levels {
+                let syms = self
+                    .xkb_keymap
+                    .key_get_syms_by_level(keycode, layout, level);
+                for sym in syms {
+                    if *sym == keysym {
+                        return Some((u32::from(keycode) - EVDEV_OFFSET, level));
+                    }
+                }
+            }
+        }
+        None
     }
 
     pub fn notify_pointer_motion(&self, dx: f64, dy: f64) {
@@ -164,7 +187,20 @@ impl AppData {
         }
     }
 
-    pub fn notify_keyboard_keysym(&self, keysym: i32, state: u32) {
-        self.virtual_keyboard.key(100, keysym as u32, state);
+    pub fn notify_keyboard_keysym(&mut self, keysym: i32, state: u32) {
+        if let Some((keycode, level)) = self.get_keycode_from_keysym(Keysym::new(keysym as u32)) {
+            match level {
+                0 => {}
+                1 => self.notify_keyboard_keycode(LEFT_SHIFT, state),
+                2 => self.notify_keyboard_keycode(ALTGR, state),
+                _ => tracing::warn!(
+                    "Received unsupported key level during keysym conversion: {}",
+                    level
+                ),
+            }
+            self.notify_keyboard_keycode(keycode as i32, state);
+        } else {
+            tracing::warn!("Could not find keycode for keysym: {}", keysym);
+        }
     }
 }


### PR DESCRIPTION
This PR implements keysyms management and addresses issue #80. `AppData` now includes `xkb` objects, necessary to map keysyms received by the D-Bus method [`NotifyKeyboardKeysym`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.RemoteDesktop.html#org-freedesktop-portal-remotedesktop-notifykeyboardkeysym) to keycodes that will be passed to the virtual keyboard. Keycodes and keysyms are both represented by integers, but they have a different semantic meaning: a keysym can represent a keycode with a modifier (i.e. there is a Keysym that represents `a` and another that represents `a + AltGr` or `a + Shift`). This means a keycode is mapped to different keysysms depending on the modifers active. For this reason, each keysym is mapped to a keycode and a level (which represents the modifiers state), with level 0 being the absence of depressed modifiers.

The implementation logic was inspired by [`xdg-desktop-portal-kde`](https://invent.kde.org/plasma/xdg-desktop-portal-kde): keysyms are firstly parsed to keycodes (using `libxkbcommon`) to be able to use the method `notify_keyboard_keycode` on the extracted keycodes. `/usr/share/X11/xkb/symbols/` contains the layout mappings from keycodes to keysyms depending on the level. As far as I understand, different layouts can bind levels to modifier combinations differently, therefore I kept the same logic employed in the KDE implementation: only the first three levels are used.

Note: `xkb_keymap_key_get_syms_by_level` allows multiple keysyms given a pair `(keycode, level)`. The wanted keysym is looked up among all the returned keysyms, but as explained in [this PR from Mutter](https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/3306), `xkb_state_key_get_one_sym` would be an alternative to `xkb_state_key_get_syms` to avoid this scenario. It would require to keep the `xkb_state` updated by reacting to `wl_keyboard` events (see Issue #88).
