### PR TITLE
 feat: add mock touch event handlers 

### DIFF
--- a/src/remotedesktop.rs
+++ b/src/remotedesktop.rs
@@ -400,4 +400,37 @@ impl RemoteDesktopBackend {
         )
         .await
     }
+
+    async fn notify_touch_down(
+        &self,
+        session_handle: ObjectPath<'_>,
+        _options: HashMap<String, Value<'_>>,
+        _stream: u32,
+        slot: u32,
+        x: f64,
+        y: f64,
+    ) -> zbus::fdo::Result<()> {
+        notify_input_event(session_handle, InputRequest::TouchDown { slot, x, y }).await
+    }
+
+    async fn notify_touch_motion(
+        &self,
+        session_handle: ObjectPath<'_>,
+        _options: HashMap<String, Value<'_>>,
+        _stream: u32,
+        slot: u32,
+        x: f64,
+        y: f64,
+    ) -> zbus::fdo::Result<()> {
+        notify_input_event(session_handle, InputRequest::TouchMotion { slot, x, y }).await
+    }
+
+    async fn notify_touch_up(
+        &self,
+        session_handle: ObjectPath<'_>,
+        _options: HashMap<String, Value<'_>>,
+        slot: u32,
+    ) -> zbus::fdo::Result<()> {
+        notify_input_event(session_handle, InputRequest::TouchUp { slot }).await
+    }
 }

--- a/src/remotedesktop.rs
+++ b/src/remotedesktop.rs
@@ -28,7 +28,7 @@ use crate::session::{
 
 use crate::PortalResponse;
 
-use self::remote_thread::KeyOrPointerRequest;
+use self::remote_thread::InputRequest;
 
 #[derive(Type, Debug, Default, Serialize, Deserialize)]
 /// Specified options for a [`Screencast::create_session`] request.
@@ -312,7 +312,7 @@ impl RemoteDesktopBackend {
         let remote_control = &session.remote_control;
         remote_control
             .sender
-            .send(KeyOrPointerRequest::PointerMotion { dx, dy })
+            .send(InputRequest::PointerMotion { dx, dy })
             .map_err(|_| zbus::Error::Failure("Send failed".to_string()))?;
         Ok(())
     }
@@ -335,7 +335,7 @@ impl RemoteDesktopBackend {
         let remote_control = &session.remote_control;
         remote_control
             .sender
-            .send(KeyOrPointerRequest::PointerMotionAbsolute { x, y })
+            .send(InputRequest::PointerMotionAbsolute { x, y })
             .map_err(|_| zbus::Error::Failure("Send failed".to_string()))?;
         Ok(())
     }
@@ -357,7 +357,7 @@ impl RemoteDesktopBackend {
         let remote_control = &session.remote_control;
         remote_control
             .sender
-            .send(KeyOrPointerRequest::PointerButton { button, state })
+            .send(InputRequest::PointerButton { button, state })
             .map_err(|_| zbus::Error::Failure("Send failed".to_string()))?;
         Ok(())
     }
@@ -379,7 +379,7 @@ impl RemoteDesktopBackend {
         let remote_control = &session.remote_control;
         remote_control
             .sender
-            .send(KeyOrPointerRequest::PointerAxis { dx, dy })
+            .send(InputRequest::PointerAxis { dx, dy })
             .map_err(|_| zbus::Error::Failure("Send failed".to_string()))?;
         Ok(())
     }
@@ -401,7 +401,7 @@ impl RemoteDesktopBackend {
         let remote_control = &session.remote_control;
         remote_control
             .sender
-            .send(KeyOrPointerRequest::PointerAxisDiscrate { axis, steps })
+            .send(InputRequest::PointerAxisDiscrate { axis, steps })
             .map_err(|_| zbus::Error::Failure("Send failed".to_string()))?;
         Ok(())
     }
@@ -423,7 +423,7 @@ impl RemoteDesktopBackend {
         let remote_control = &session.remote_control;
         remote_control
             .sender
-            .send(KeyOrPointerRequest::KeyboardKeycode { keycode, state })
+            .send(InputRequest::KeyboardKeycode { keycode, state })
             .map_err(|_| zbus::Error::Failure("Send failed".to_string()))?;
         Ok(())
     }
@@ -445,7 +445,7 @@ impl RemoteDesktopBackend {
         let remote_control = &session.remote_control;
         remote_control
             .sender
-            .send(KeyOrPointerRequest::KeyboardKeysym { keysym, state })
+            .send(InputRequest::KeyboardKeysym { keysym, state })
             .map_err(|_| zbus::Error::Failure("Send failed".to_string()))?;
         Ok(())
     }

--- a/src/remotedesktop/remote_thread.rs
+++ b/src/remotedesktop/remote_thread.rs
@@ -22,7 +22,7 @@ use calloop::EventLoop;
 use calloop_wayland_source::WaylandSource;
 
 #[derive(Debug)]
-pub enum KeyOrPointerRequest {
+pub enum InputRequest {
     PointerMotion { dx: f64, dy: f64 },
     PointerMotionAbsolute { x: f64, y: f64 },
     PointerButton { button: i32, state: u32 },
@@ -35,7 +35,7 @@ pub enum KeyOrPointerRequest {
 
 #[derive(Debug)]
 pub struct RemoteControl {
-    pub sender: Sender<KeyOrPointerRequest>,
+    pub sender: Sender<InputRequest>,
 }
 
 impl RemoteControl {
@@ -48,12 +48,12 @@ impl RemoteControl {
     }
 
     pub fn stop(&self) {
-        let _ = self.sender.send(KeyOrPointerRequest::Exit);
+        let _ = self.sender.send(InputRequest::Exit);
     }
 }
 
 pub fn remote_loop(
-    receiver: Receiver<KeyOrPointerRequest>,
+    receiver: Receiver<InputRequest>,
     output_width: u32,
     output_height: u32,
 ) -> Result<(), KeyPointerError> {
@@ -113,7 +113,7 @@ pub fn remote_loop(
 
     let to_exit = Arc::new(AtomicBool::new(false));
 
-    let events: Arc<Mutex<Vec<KeyOrPointerRequest>>> = Arc::new(Mutex::new(Vec::new()));
+    let events: Arc<Mutex<Vec<InputRequest>>> = Arc::new(Mutex::new(Vec::new()));
 
     let to_exit2 = to_exit.clone();
     let to_exit3 = to_exit.clone();
@@ -153,28 +153,26 @@ pub fn remote_loop(
                 drop(local_events);
                 for message in swapped_events {
                     match message {
-                        KeyOrPointerRequest::PointerMotion { dx, dy } => {
+                        InputRequest::PointerMotion { dx, dy } => {
                             data.notify_pointer_motion(dx, dy)
                         }
-                        KeyOrPointerRequest::PointerMotionAbsolute { x, y } => {
+                        InputRequest::PointerMotionAbsolute { x, y } => {
                             data.notify_pointer_motion_absolute(x, y)
                         }
-                        KeyOrPointerRequest::PointerButton { button, state } => {
+                        InputRequest::PointerButton { button, state } => {
                             data.notify_pointer_button(button, state)
                         }
-                        KeyOrPointerRequest::PointerAxis { dx, dy } => {
-                            data.notify_pointer_axis(dx, dy)
-                        }
-                        KeyOrPointerRequest::PointerAxisDiscrate { axis, steps } => {
+                        InputRequest::PointerAxis { dx, dy } => data.notify_pointer_axis(dx, dy),
+                        InputRequest::PointerAxisDiscrate { axis, steps } => {
                             data.notify_pointer_axis_discrete(axis, steps)
                         }
-                        KeyOrPointerRequest::KeyboardKeycode { keycode, state } => {
+                        InputRequest::KeyboardKeycode { keycode, state } => {
                             data.notify_keyboard_keycode(keycode, state)
                         }
-                        KeyOrPointerRequest::KeyboardKeysym { keysym, state } => {
+                        InputRequest::KeyboardKeysym { keysym, state } => {
                             data.notify_keyboard_keysym(keysym, state)
                         }
-                        KeyOrPointerRequest::Exit => {
+                        InputRequest::Exit => {
                             signal.stop();
                             break;
                         }

--- a/src/remotedesktop/remote_thread.rs
+++ b/src/remotedesktop/remote_thread.rs
@@ -30,6 +30,9 @@ pub enum InputRequest {
     PointerAxisDiscrate { axis: u32, steps: i32 },
     KeyboardKeycode { keycode: i32, state: u32 },
     KeyboardKeysym { keysym: i32, state: u32 },
+    TouchMotion { slot: u32, x: f64, y: f64 },
+    TouchDown { slot: u32, x: f64, y: f64 },
+    TouchUp { slot: u32 },
     Exit,
 }
 
@@ -171,6 +174,15 @@ pub fn remote_loop(
                         }
                         InputRequest::KeyboardKeysym { keysym, state } => {
                             data.notify_keyboard_keysym(keysym, state)
+                        }
+                        InputRequest::TouchDown { slot, x, y } => {
+                            data.notify_touch_down(slot, x, y);
+                        }
+                        InputRequest::TouchMotion { slot, x, y } => {
+                            data.notify_touch_motion(slot, x, y);
+                        }
+                        InputRequest::TouchUp { slot } => {
+                            data.notify_touch_up(slot);
                         }
                         InputRequest::Exit => {
                             signal.stop();

--- a/src/remotedesktop/state.rs
+++ b/src/remotedesktop/state.rs
@@ -203,4 +203,16 @@ impl AppData {
             tracing::warn!("Could not find keycode for keysym: {}", keysym);
         }
     }
+
+    pub fn notify_touch_down(&mut self, _slot: u32, _x: f64, _y: f64) {
+        tracing::debug!("NotifyTouchDown: touch events are currently unsupported");
+    }
+
+    pub fn notify_touch_motion(&mut self, _slot: u32, _x: f64, _y: f64) {
+        tracing::debug!("NotifyTouchMotion: touch events are currently unsupported");
+    }
+
+    pub fn notify_touch_up(&mut self, _slot: u32) {
+        tracing::debug!("NotifyTouchUp: touch events are currently unsupported");
+    }
 }


### PR DESCRIPTION
[`RemoteDesktop`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.impl.portal.RemoteDesktop.html) has methods to notify touch events (`NotifyTouchDown`, `NotifyTouchMotion` and `NotifyTouchUp`). However, there's not yet a Wayland protocol implemented by wlroots to simulate touch events. Therefore, a mock implementation was added, with just a debug trace that signals that touch events are currently not supported. A small refactoring was performed before adding touch event handlers:
- `KeyOrPointerRequest` was renamed to `InputRequest` as it now contains touch events as well
- Common code from  `RemoteDesktopBackend` methods was moved to a separate method to avoid code repetitions.