### PR TITLE
Add VideoFormat handling for PipeWire streams

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
             - uses: actions/checkout@v4
             - name: "install deps"
               run: |
-                pacman -Syu --noconfirm base-devel clang meson ninja pipewire libxkbcommon wayland cairo pango
+                pacman -Syu --noconfirm base-devel clang meson ninja pipewire libxkbcommon wayland cairo pango egl-wayland
             - uses: dtolnay/rust-toolchain@stable
               with:
                 components: clippy rustfmt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1805,6 +1805,8 @@ dependencies = [
  "drm-fourcc",
  "gbm-sys",
  "libc",
+ "wayland-backend",
+ "wayland-server",
 ]
 
 [[package]]
@@ -1993,6 +1995,15 @@ dependencies = [
  "libc",
  "system-deps 7.0.3",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "gl"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a94edab108827d67608095e269cf862e60d920f144a5026d3dbcfd8b877fb404"
+dependencies = [
+ "gl_generator",
 ]
 
 [[package]]
@@ -2956,6 +2967,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "khronos-egl"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "khronos_api"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3092,18 +3113,21 @@ dependencies = [
 
 [[package]]
 name = "libwayshot"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2efa01ecfd021b1e7db27f21f4e79b35b048081c9cae9d2f898eddc98444d69"
+version = "0.3.2-dev"
 dependencies = [
- "image 0.24.9",
- "log",
+ "drm",
+ "gbm",
+ "gl",
+ "image 0.25.6",
+ "khronos-egl",
  "memmap2",
- "nix 0.27.1",
- "thiserror 1.0.69",
+ "rustix 1.0.7",
+ "thiserror 2.0.12",
+ "tracing",
+ "wayland-backend",
  "wayland-client",
- "wayland-protocols 0.31.2",
- "wayland-protocols-wlr 0.2.0",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
 ]
 
 [[package]]
@@ -3120,8 +3144,8 @@ dependencies = [
  "thiserror 2.0.12",
  "wayland-client",
  "wayland-cursor",
- "wayland-protocols 0.32.8",
- "wayland-protocols-wlr 0.3.8",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
 ]
 
 [[package]]
@@ -4976,8 +5000,8 @@ dependencies = [
  "wayland-client",
  "wayland-csd-frame",
  "wayland-cursor",
- "wayland-protocols 0.32.8",
- "wayland-protocols-wlr 0.3.8",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
  "wayland-scanner",
  "xkeysym",
 ]
@@ -5913,18 +5937,6 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.31.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f81f365b8b4a97f422ac0e8737c438024b5951734506b0e1d775c73030561f4"
-dependencies = [
- "bitflags 2.9.0",
- "wayland-backend",
- "wayland-client",
- "wayland-scanner",
-]
-
-[[package]]
-name = "wayland-protocols"
 version = "0.32.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "779075454e1e9a521794fed15886323ea0feda3f8b0fc1390f5398141310422a"
@@ -5944,7 +5956,7 @@ dependencies = [
  "bitflags 2.9.0",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols 0.32.8",
+ "wayland-protocols",
  "wayland-scanner",
 ]
 
@@ -5957,20 +5969,7 @@ dependencies = [
  "bitflags 2.9.0",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols 0.32.8",
- "wayland-scanner",
-]
-
-[[package]]
-name = "wayland-protocols-wlr"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1f61b76b6c2d8742e10f9ba5c3737f6530b4c243132c2a2ccc8aa96fe25cd6"
-dependencies = [
- "bitflags 2.9.0",
- "wayland-backend",
- "wayland-client",
- "wayland-protocols 0.31.2",
+ "wayland-protocols",
  "wayland-scanner",
 ]
 
@@ -5983,7 +5982,7 @@ dependencies = [
  "bitflags 2.9.0",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols 0.32.8",
+ "wayland-protocols",
  "wayland-scanner",
 ]
 
@@ -5999,13 +5998,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-server"
+version = "0.31.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "485dfb8ccf0daa0d34625d34e6ac15f99e550a7999b6fd88a0835ccd37655785"
+dependencies = [
+ "bitflags 2.9.0",
+ "downcast-rs",
+ "rustix 0.38.44",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
 name = "wayland-sys"
 version = "0.31.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbcebb399c77d5aa9fa5db874806ee7b4eba4e73650948e8f93963f128896615"
 dependencies = [
  "dlib",
+ "libc",
  "log",
+ "memoffset",
  "once_cell",
  "pkg-config",
 ]
@@ -6561,7 +6575,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols 0.32.8",
+ "wayland-protocols",
  "wayland-protocols-plasma",
  "web-sys",
  "web-time",
@@ -6711,9 +6725,9 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "wayland-client",
- "wayland-protocols 0.32.8",
+ "wayland-protocols",
  "wayland-protocols-misc",
- "wayland-protocols-wlr 0.3.8",
+ "wayland-protocols-wlr",
  "xkbcommon",
  "zbus 5.9.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3114,6 +3114,7 @@ dependencies = [
 [[package]]
 name = "libwayshot"
 version = "0.3.2-dev"
+source = "git+https://github.com/waycrate/wayshot#ff47e49d37e2af6dd0a8a9bf114e14a7a21153a3"
 dependencies = [
  "drm",
  "gbm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ anyhow = "1.0.98"
 pipewire = "0.8.0"
 libspa-sys = "0.8.0"
 
-libwayshot = { version = "0.3.0" }
+libwayshot = { path="../wayshot/libwayshot" }
 rustix = { version = "1.0.5", features = ["fs", "use-libc"] }
 
 # REMOTE

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ anyhow = "1.0.98"
 pipewire = "0.8.0"
 libspa-sys = "0.8.0"
 
-libwayshot = { path="../wayshot/libwayshot" }
+libwayshot = { git = "https://github.com/waycrate/wayshot" }
 rustix = { version = "1.0.5", features = ["fs", "use-libc"] }
 
 # REMOTE

--- a/src/pipewirethread.rs
+++ b/src/pipewirethread.rs
@@ -3,14 +3,14 @@ use libwayshot::{WayshotConnection, reexport::WlOutput};
 use pipewire::{
     spa::{
         self,
-        param::video::VideoInfoRaw,
+        param::video::{VideoFormat, VideoInfoRaw},
         pod::{self, serialize::PodSerializer},
     },
     stream::StreamState,
 };
 use rustix::fd::BorrowedFd;
-
 use std::{cell::RefCell, io, os::fd::IntoRawFd, rc::Rc, slice};
+use wayland_client::protocol::wl_shm::Format;
 
 use tokio::sync::oneshot;
 
@@ -70,7 +70,7 @@ impl ScreencastThread {
 
 type PipewireStreamResult = (
     pipewire::main_loop::MainLoop,
-    pipewire::stream::StreamListener<()>,
+    pipewire::stream::StreamListener<Option<Format>>,
     pipewire::context::Context,
     oneshot::Receiver<anyhow::Result<u32>>,
 );
@@ -103,8 +103,22 @@ fn start_stream(
     let stream_cell: Rc<RefCell<Option<pipewire::stream::Stream>>> = Rc::new(RefCell::new(None));
     let stream_cell_clone = stream_cell.clone();
 
+    let available_video_formats = match connection.get_available_frame_formats(&output) {
+        Ok(frame_format_list) => frame_format_list
+            .iter()
+            .filter_map(|frame_format| wl_shm_format_to_spa(frame_format.format))
+            .collect(),
+        Err(e) => {
+            tracing::warn!("Could not get available video formats from libwayshot: {e}");
+            // Xrgb8888 and Argb8888 should be supported by all renderers
+            // https://smithay.github.io/wayland-rs/wayland_client/protocol/wl_shm/enum.Format.html
+            vec![VideoFormat::BGRx, VideoFormat::BGRA]
+        }
+    };
+    let chosen_format: Option<Format> = None;
+
     let listener = stream
-        .add_local_listener_with_user_data(())
+        .add_local_listener_with_user_data(chosen_format)
         .state_changed(move |_, _, old, new| {
             tracing::info!("state-changed '{:?}' -> '{:?}'", old, new);
             match new {
@@ -121,17 +135,17 @@ fn start_stream(
                 _ => {}
             }
         })
-        .param_changed(|_, _, id, pod| {
+        .param_changed(|_, chosen_format, id, pod| {
             if id != libspa_sys::SPA_PARAM_Format {
                 return;
             }
             if let Some(pod) = pod {
                 let mut chosen_format_info = VideoInfoRaw::new();
                 match chosen_format_info.parse(pod) {
-                    Ok(_) => tracing::info!(
-                        "param-changed: chosen format id is {}",
-                        chosen_format_info.format().as_raw()
-                    ),
+                    Ok(_) => {
+                        *chosen_format =
+                            Some(spa_format_to_wl_shm(chosen_format_info.format()).unwrap())
+                    }
                     Err(e) => {
                         tracing::error!("Could not parse format chosen by PipeWire server: {e}")
                     }
@@ -168,24 +182,34 @@ fn start_stream(
                 data.fd = -1;
             }
         })
-        .process(move |stream, ()| {
+        .process(move |stream, chosen_format| {
             if let Some(mut buffer) = stream.dequeue_buffer() {
                 let datas = buffer.datas_mut();
                 let fd = unsafe { BorrowedFd::borrow_raw(datas[0].as_raw().fd as _) };
-                // TODO error
-                connection
-                    .capture_output_frame_shm_fd(
-                        overlay_cursor as i32,
-                        &output,
-                        fd,
-                        embedded_region,
-                    )
-                    .unwrap();
+                match chosen_format {
+                    Some(format) => {
+                        // TODO error
+                        connection
+                            .capture_output_frame_shm_fd_with_format(
+                                overlay_cursor as i32,
+                                &output,
+                                fd,
+                                *format,
+                                embedded_region,
+                            )
+                            .unwrap();
+                    }
+                    None => {
+                        tracing::error!(
+                            "Pipewire: couldn't capture video frames, chosen format is empty"
+                        );
+                    }
+                }
             }
         })
         .register()?;
 
-    let format = format(width, height);
+    let format = format(width, height, available_video_formats);
     let buffers = buffers(width, height);
 
     let params = &mut [
@@ -270,7 +294,7 @@ fn buffers2(width: u32, height: u32) -> Vec<u8> {
     )))
 }
 
-fn format(width: u32, height: u32) -> Vec<u8> {
+fn format(width: u32, height: u32, available_video_formats: Vec<VideoFormat>) -> Vec<u8> {
     let mut obj = spa::pod::object!(
         spa::utils::SpaTypes::ObjectParamFormat,
         spa::param::ParamType::EnumFormat,
@@ -305,20 +329,13 @@ fn format(width: u32, height: u32) -> Vec<u8> {
         ),
         // TODO max framerate
     );
-    let video_formats = vec![
-        spa::param::video::VideoFormat::RGBA,
-        spa::param::video::VideoFormat::RGBx,
-        spa::param::video::VideoFormat::RGB8P,
-        spa::param::video::VideoFormat::BGR,
-        spa::param::video::VideoFormat::YUY2,
-    ];
 
     let format_choice =
         pod::Value::Choice(pod::ChoiceValue::Id(spa::utils::Choice::<spa::utils::Id>(
             spa::utils::ChoiceFlags::empty(),
             spa::utils::ChoiceEnum::<spa::utils::Id>::Enum {
-                default: spa::utils::Id(video_formats[0].as_raw()),
-                alternatives: video_formats
+                default: spa::utils::Id(VideoFormat::BGRA.as_raw()),
+                alternatives: available_video_formats
                     .iter()
                     .map(|f| spa::utils::Id(f.as_raw()))
                     .collect(),
@@ -331,4 +348,49 @@ fn format(width: u32, height: u32) -> Vec<u8> {
         value: format_choice,
     });
     value_to_bytes(pod::Value::Object(obj))
+}
+
+// wl_shm::Format uses FourCC codes, hence the conversion logic
+fn spa_format_to_wl_shm(format: VideoFormat) -> Option<Format> {
+    match format {
+        VideoFormat::BGRA => Some(Format::Argb8888),
+        VideoFormat::BGRx => Some(Format::Xrgb8888),
+        VideoFormat::ABGR => Some(Format::Rgba8888),
+        VideoFormat::xBGR => Some(Format::Rgbx8888),
+        VideoFormat::RGBA => Some(Format::Abgr8888),
+        VideoFormat::RGBx => Some(Format::Xbgr8888),
+        VideoFormat::ARGB => Some(Format::Bgra8888),
+        VideoFormat::xRGB => Some(Format::Bgrx8888),
+        VideoFormat::xRGB_210LE => Some(Format::Xrgb2101010),
+        VideoFormat::xBGR_210LE => Some(Format::Xbgr2101010),
+        VideoFormat::RGBx_102LE => Some(Format::Rgbx1010102),
+        VideoFormat::BGRx_102LE => Some(Format::Bgrx1010102),
+        VideoFormat::ARGB_210LE => Some(Format::Argb2101010),
+        VideoFormat::ABGR_210LE => Some(Format::Abgr2101010),
+        VideoFormat::RGBA_102LE => Some(Format::Rgba1010102),
+        VideoFormat::BGRA_102LE => Some(Format::Bgra1010102),
+        _ => None,
+    }
+}
+
+fn wl_shm_format_to_spa(format: Format) -> Option<VideoFormat> {
+    match format {
+        Format::Argb8888 => Some(VideoFormat::BGRA),
+        Format::Xrgb8888 => Some(VideoFormat::BGRx),
+        Format::Rgba8888 => Some(VideoFormat::ABGR),
+        Format::Rgbx8888 => Some(VideoFormat::xBGR),
+        Format::Abgr8888 => Some(VideoFormat::RGBA),
+        Format::Xbgr8888 => Some(VideoFormat::RGBx),
+        Format::Bgra8888 => Some(VideoFormat::ARGB),
+        Format::Bgrx8888 => Some(VideoFormat::xRGB),
+        Format::Xrgb2101010 => Some(VideoFormat::xRGB_210LE),
+        Format::Xbgr2101010 => Some(VideoFormat::xBGR_210LE),
+        Format::Rgbx1010102 => Some(VideoFormat::RGBx_102LE),
+        Format::Bgrx1010102 => Some(VideoFormat::BGRx_102LE),
+        Format::Argb2101010 => Some(VideoFormat::ARGB_210LE),
+        Format::Abgr2101010 => Some(VideoFormat::ABGR_210LE),
+        Format::Rgba1010102 => Some(VideoFormat::RGBA_102LE),
+        Format::Bgra1010102 => Some(VideoFormat::BGRA_102LE),
+        _ => None,
+    }
 }

--- a/src/pipewirethread.rs
+++ b/src/pipewirethread.rs
@@ -1,4 +1,4 @@
-use libwayshot::CaptureRegion;
+use libwayshot::region::EmbeddedRegion;
 use libwayshot::{WayshotConnection, reexport::WlOutput};
 use pipewire::{
     spa::{
@@ -24,7 +24,7 @@ impl ScreencastThread {
         overlay_cursor: bool,
         width: u32,
         height: u32,
-        capture_region: Option<CaptureRegion>,
+        embedded_region: Option<EmbeddedRegion>,
         output: WlOutput,
         connection: WayshotConnection,
     ) -> anyhow::Result<Self> {
@@ -36,7 +36,7 @@ impl ScreencastThread {
                 overlay_cursor,
                 width,
                 height,
-                capture_region,
+                embedded_region,
                 output,
             ) {
                 Ok((loop_, listener, context, node_id_rx)) => {
@@ -80,7 +80,7 @@ fn start_stream(
     overlay_cursor: bool,
     width: u32,
     height: u32,
-    capture_region: Option<CaptureRegion>,
+    embedded_region: Option<EmbeddedRegion>,
     output: WlOutput,
 ) -> Result<PipewireStreamResult, pipewire::Error> {
     let loop_ = pipewire::main_loop::MainLoop::new(None).unwrap();
@@ -174,7 +174,12 @@ fn start_stream(
                 let fd = unsafe { BorrowedFd::borrow_raw(datas[0].as_raw().fd as _) };
                 // TODO error
                 connection
-                    .capture_output_frame_shm_fd(overlay_cursor as i32, &output, fd, capture_region)
+                    .capture_output_frame_shm_fd(
+                        overlay_cursor as i32,
+                        &output,
+                        fd,
+                        embedded_region,
+                    )
                     .unwrap();
             }
         })


### PR DESCRIPTION
This PR addresses issue #103 and works with [wayshot/pull/207](https://github.com/waycrate/wayshot/pull/207).

It modifies Screencast streams to be initialized with a valid vector of supported formats, and handles the `param_changed` events received by the PipeWire server to signal the chosen format among the available ones. Video frame capture is modified to be performed using the negotiated format. `libwayshot` code references are updated to support the current state on the `main` branch, enabling a dependency bump. Conversion between `wl_shm::Format` and `spa::param::video::VideoFormat` is added as well.
