### PR TITLE
Implement Background Portal

### DIFF
--- a/misc/luminous.portal
+++ b/misc/luminous.portal
@@ -1,3 +1,3 @@
 [portal]
 DBusName=org.freedesktop.impl.portal.desktop.luminous
-Interfaces=org.freedesktop.impl.portal.Screenshot;org.freedesktop.impl.portal.ScreenCast;org.freedesktop.impl.portal.RemoteDesktop;org.freedesktop.impl.portal.InputCapture;org.freedesktop.impl.portal.Settings;org.freedesktop.impl.portal.Access;
+Interfaces=org.freedesktop.impl.portal.Screenshot;org.freedesktop.impl.portal.ScreenCast;org.freedesktop.impl.portal.RemoteDesktop;org.freedesktop.impl.portal.InputCapture;org.freedesktop.impl.portal.Settings;org.freedesktop.impl.portal.Access;org.freedesktop.impl.portal.Background;

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,4 +1,5 @@
 use crate::access::AccessBackend;
+use crate::background::{BackgroundBackend, PendingBackgroundResponses};
 use crate::input_capture::InputCapture;
 use crate::remotedesktop::RemoteDesktopBackend;
 use crate::screencast::ScreenCastBackend;
@@ -8,16 +9,22 @@ use crate::settings::{AccentColor, SETTING_CONFIG, SettingsBackend, SettingsConf
 use crate::dialog::{CopySelect, Message};
 use futures::{
     SinkExt, StreamExt,
-    channel::mpsc::{Receiver, Sender, channel},
+    channel::mpsc::{Receiver, Sender, UnboundedReceiver, channel},
 };
 use notify::{Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use std::collections::{HashMap, HashSet};
 use std::future::pending;
 use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::{Mutex, mpsc as tokio_mpsc};
+use tokio::time::MissedTickBehavior;
 use zbus::{Connection, connection, object_server::SignalEmitter};
 
 use std::sync::OnceLock;
 
 static SESSION: OnceLock<zbus::Connection> = OnceLock::new();
+const SYSTEMD_SIGNAL_RETRY_BACKOFF: Duration = Duration::from_secs(5);
 
 async fn get_connection() -> zbus::Connection {
     if let Some(cnx) = SESSION.get() {
@@ -119,10 +126,13 @@ pub async fn backend(
     sender: Sender<Message>,
     receiver: Receiver<CopySelect>,
     receiver_cast: Receiver<CopySelect>,
+    receiver_background: UnboundedReceiver<CopySelect>,
 ) -> anyhow::Result<()> {
     let toplevel_capture_support = libwayshot::WayshotConnection::new()
         .map(|conn| conn.toplevel_capture_support())
         .unwrap_or(false);
+    let pending_background_responses: PendingBackgroundResponses =
+        Arc::new(Mutex::new(Default::default()));
     let conn = connection::Builder::session()?
         .name("org.freedesktop.impl.portal.desktop.luminous")?
         .serve_at("/org/freedesktop/portal/desktop", AccessBackend)?
@@ -137,8 +147,15 @@ pub async fn backend(
             "/org/freedesktop/portal/desktop",
             ScreenCastBackend {
                 toplevel_capture_support,
-                sender,
+                sender: sender.clone(),
                 receiver: receiver_cast,
+            },
+        )?
+        .serve_at(
+            "/org/freedesktop/portal/desktop",
+            BackgroundBackend {
+                sender,
+                pending_responses: pending_background_responses.clone(),
             },
         )?
         .serve_at("/org/freedesktop/portal/desktop", RemoteDesktopBackend)?
@@ -148,6 +165,18 @@ pub async fn backend(
         .await?;
 
     set_connection(conn).await;
+    tokio::spawn(crate::background::route_background_dialog_responses(
+        receiver_background,
+        pending_background_responses,
+    ));
+
+    let background_connection = get_connection().await;
+    tokio::spawn(async move {
+        if let Err(e) = watch_background_applications(background_connection).await {
+            tracing::info!("Cannot watch systemd app scopes: {e}");
+        }
+    });
+
     tokio::spawn(async {
         let Ok(home) = std::env::var("HOME") else {
             return;
@@ -174,6 +203,314 @@ pub async fn backend(
         SignalEmitter::new(&connection, "/org/freedesktop/portal/desktop").unwrap();
     update_settings(&signal_context).await;
     pending::<()>().await;
+
+    Ok(())
+}
+
+async fn watch_background_applications(connection: Connection) -> zbus::Result<()> {
+    let mut app_scope_tracker = AppScopeTracker::default();
+    let mut app_scope_tracker_seeded = false;
+    let (systemd_event_sender, mut systemd_event_receiver) = tokio_mpsc::channel(32);
+    tokio::spawn(forward_systemd_scope_signals(
+        connection.clone(),
+        systemd_event_sender,
+    ));
+
+    let signal_context =
+        SignalEmitter::new(&connection, "/org/freedesktop/portal/desktop").unwrap();
+    let mut last_windowed_app_ids = collect_windowed_app_ids().unwrap_or_default();
+    let mut window_poll = tokio::time::interval(Duration::from_secs(10));
+    window_poll.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    window_poll.tick().await;
+
+    loop {
+        tokio::select! {
+            Some(event) = systemd_event_receiver.recv() => {
+                match event {
+                    SystemdMonitorEvent::Signal { signal, message } => {
+                        if let Err(e) = emit_running_applications_changed_for_app_scope(
+                            &signal_context,
+                            &mut app_scope_tracker,
+                            signal,
+                            &message,
+                        )
+                        .await {
+                            tracing::warn!(
+                                "Failed to emit RunningApplicationsChanged for systemd app scope signal: {e}"
+                            );
+                        }
+                    }
+                    SystemdMonitorEvent::Reconcile(units) => {
+                        if !app_scope_tracker_seeded {
+                            app_scope_tracker = AppScopeTracker::from_units(units);
+                            app_scope_tracker_seeded = true;
+                            continue;
+                        }
+
+                        let emit_result = if app_scope_tracker.reconcile_units(units) {
+                            BackgroundBackend::running_applications_changed(&signal_context).await
+                        } else {
+                            Ok(())
+                        };
+                        if let Err(e) = emit_result {
+                            tracing::warn!(
+                                "Failed to emit RunningApplicationsChanged after systemd app scope reconciliation: {e}"
+                            );
+                        }
+                    }
+                }
+            }
+            _ = window_poll.tick() => {
+                emit_running_applications_changed_for_windowed_apps(
+                    &signal_context,
+                    &mut last_windowed_app_ids,
+                )
+                .await;
+            }
+        }
+    }
+}
+
+async fn forward_systemd_scope_signals(
+    connection: Connection,
+    sender: tokio_mpsc::Sender<SystemdMonitorEvent>,
+) {
+    loop {
+        if sender.is_closed() {
+            return;
+        }
+
+        match forward_systemd_scope_signals_once(&connection, &sender).await {
+            Ok(()) if sender.is_closed() => return,
+            Ok(()) => {
+                tracing::warn!(
+                    "Systemd app scope signal stream ended; retrying in {} seconds",
+                    SYSTEMD_SIGNAL_RETRY_BACKOFF.as_secs()
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "Cannot watch systemd app scope signals: {e}; retrying in {} seconds",
+                    SYSTEMD_SIGNAL_RETRY_BACKOFF.as_secs()
+                );
+            }
+        }
+
+        tokio::time::sleep(SYSTEMD_SIGNAL_RETRY_BACKOFF).await;
+    }
+}
+
+async fn forward_systemd_scope_signals_once(
+    connection: &Connection,
+    sender: &tokio_mpsc::Sender<SystemdMonitorEvent>,
+) -> zbus::Result<()> {
+    let systemd = crate::systemd::Systemd1Proxy::new(connection).await?;
+    let proxy = zbus::Proxy::new(
+        connection,
+        "org.freedesktop.systemd1",
+        "/org/freedesktop/systemd1",
+        "org.freedesktop.systemd1.Manager",
+    )
+    .await?;
+
+    let mut unit_new = proxy.receive_signal("UnitNew").await?;
+    let mut unit_removed = proxy.receive_signal("UnitRemoved").await?;
+    systemd.subscribe().await?;
+
+    let units = systemd.list_units().await?;
+    if sender
+        .send(SystemdMonitorEvent::Reconcile(units))
+        .await
+        .is_err()
+    {
+        return Ok(());
+    }
+
+    loop {
+        tokio::select! {
+            message = unit_new.next() => {
+                match message {
+                    Some(message) => {
+                        if sender.send(SystemdMonitorEvent::Signal {
+                            signal: UnitSignal::New,
+                            message,
+                        }).await.is_err() {
+                            return Ok(());
+                        }
+                    }
+                    None => return Ok(()),
+                }
+            }
+            message = unit_removed.next() => {
+                match message {
+                    Some(message) => {
+                        if sender.send(SystemdMonitorEvent::Signal {
+                            signal: UnitSignal::Removed,
+                            message,
+                        }).await.is_err() {
+                            return Ok(());
+                        }
+                    }
+                    None => return Ok(()),
+                }
+            }
+        }
+    }
+}
+
+async fn emit_running_applications_changed_for_windowed_apps(
+    signal_context: &SignalEmitter<'_>,
+    last_windowed_app_ids: &mut HashSet<String>,
+) {
+    let Some(windowed_app_ids) = collect_windowed_app_ids() else {
+        return;
+    };
+
+    if !update_windowed_app_ids(last_windowed_app_ids, windowed_app_ids) {
+        return;
+    }
+
+    if let Err(e) = BackgroundBackend::running_applications_changed(signal_context).await {
+        tracing::warn!("Failed to emit RunningApplicationsChanged for window changes: {e}");
+    }
+}
+
+fn collect_windowed_app_ids() -> Option<HashSet<String>> {
+    let mut wayshot_connection = match libwayshot::WayshotConnection::new() {
+        Ok(connection) => connection,
+        Err(e) => {
+            tracing::warn!("Cannot get Wayland toplevels for background monitor: {e:?}");
+            return None;
+        }
+    };
+
+    if let Err(e) = wayshot_connection.refresh_toplevels() {
+        tracing::warn!("Cannot refresh Wayland toplevels for background monitor: {e:?}");
+        return None;
+    }
+
+    Some(
+        wayshot_connection
+            .get_all_toplevels()
+            .iter()
+            .filter(|top_level| !top_level.app_id.is_empty())
+            .map(|top_level| top_level.app_id.clone())
+            .collect(),
+    )
+}
+
+fn update_windowed_app_ids(
+    last_windowed_app_ids: &mut HashSet<String>,
+    windowed_app_ids: HashSet<String>,
+) -> bool {
+    if windowed_app_ids == *last_windowed_app_ids {
+        false
+    } else {
+        *last_windowed_app_ids = windowed_app_ids;
+        true
+    }
+}
+
+#[derive(Clone, Copy)]
+enum UnitSignal {
+    New,
+    Removed,
+}
+
+enum SystemdMonitorEvent {
+    Signal {
+        signal: UnitSignal,
+        message: zbus::Message,
+    },
+    Reconcile(Vec<crate::systemd::Unit>),
+}
+
+#[derive(Default)]
+struct AppScopeTracker {
+    unit_app_ids: HashMap<String, String>,
+    app_unit_counts: HashMap<String, usize>,
+}
+
+impl AppScopeTracker {
+    fn from_units(units: Vec<crate::systemd::Unit>) -> Self {
+        let mut tracker = Self::default();
+        tracker.rebuild_from_unit_names(units.into_iter().map(|unit| unit.name));
+        tracker
+    }
+
+    fn reconcile_units(&mut self, units: Vec<crate::systemd::Unit>) -> bool {
+        let previous_app_ids = self.app_ids();
+        self.rebuild_from_unit_names(units.into_iter().map(|unit| unit.name));
+        self.app_ids() != previous_app_ids
+    }
+
+    fn rebuild_from_unit_names(&mut self, unit_names: impl IntoIterator<Item = String>) {
+        self.unit_app_ids.clear();
+        self.app_unit_counts.clear();
+
+        for unit_name in unit_names {
+            self.insert_unit(unit_name);
+        }
+    }
+
+    fn app_ids(&self) -> HashSet<String> {
+        self.app_unit_counts.keys().cloned().collect()
+    }
+
+    fn insert_unit(&mut self, unit_name: String) -> bool {
+        let Some(app_id) = crate::systemd::parse_app_scope_name(&unit_name).map(ToOwned::to_owned)
+        else {
+            return false;
+        };
+
+        if self.unit_app_ids.contains_key(&unit_name) {
+            return false;
+        }
+
+        let count = self.app_unit_counts.entry(app_id.clone()).or_default();
+        let app_started = *count == 0;
+        *count += 1;
+        self.unit_app_ids.insert(unit_name, app_id);
+        app_started
+    }
+
+    fn remove_unit(&mut self, unit_name: &str) -> bool {
+        let Some(app_id) = self.unit_app_ids.remove(unit_name) else {
+            return false;
+        };
+
+        let Some(count) = self.app_unit_counts.get_mut(&app_id) else {
+            return false;
+        };
+
+        *count -= 1;
+        if *count == 0 {
+            self.app_unit_counts.remove(&app_id);
+            true
+        } else {
+            false
+        }
+    }
+}
+
+async fn emit_running_applications_changed_for_app_scope(
+    signal_context: &SignalEmitter<'_>,
+    app_scope_tracker: &mut AppScopeTracker,
+    signal: UnitSignal,
+    message: &zbus::Message,
+) -> zbus::Result<()> {
+    let Some(unit_name) = crate::background::unit_name_from_systemd_signal(message) else {
+        return Ok(());
+    };
+
+    let app_set_changed = match signal {
+        UnitSignal::New => app_scope_tracker.insert_unit(unit_name),
+        UnitSignal::Removed => app_scope_tracker.remove_unit(&unit_name),
+    };
+
+    if app_set_changed {
+        BackgroundBackend::running_applications_changed(signal_context).await?;
+    }
 
     Ok(())
 }

--- a/src/background.rs
+++ b/src/background.rs
@@ -1,0 +1,639 @@
+use std::{
+    collections::{HashMap, hash_map::Entry},
+    io,
+    path::PathBuf,
+    sync::{Arc, Mutex as StdMutex},
+};
+
+use futures::{
+    SinkExt, StreamExt,
+    channel::mpsc::{Sender, UnboundedReceiver},
+};
+use libwayshot::WayshotConnection;
+use serde::Serialize;
+use tokio::sync::{Mutex, oneshot};
+use zbus::{
+    fdo, interface,
+    object_server::SignalEmitter,
+    zvariant::{ObjectPath, OwnedObjectPath, Type, as_value},
+};
+
+use crate::{
+    PortalResponse,
+    dialog::{CopySelect, Message},
+    request::{RequestCloseAction, RequestInterface},
+    settings::SETTING_CONFIG,
+    systemd::Systemd1Proxy,
+};
+
+const AUTOSTART_DBUS_ACTIVATABLE: u32 = 0x1;
+
+#[derive(Debug)]
+pub struct BackgroundBackend {
+    pub sender: Sender<Message>,
+    pub pending_responses: PendingBackgroundResponses,
+}
+
+pub type PendingBackgroundResponses = Arc<Mutex<PendingBackgroundResponseRegistry>>;
+
+#[derive(Debug, Default)]
+pub struct PendingBackgroundResponseRegistry {
+    by_handle: HashMap<String, PendingBackgroundRequest>,
+    app_handles: HashMap<String, Vec<String>>,
+}
+
+#[derive(Debug)]
+struct PendingBackgroundRequest {
+    app_id: String,
+    response_sender: oneshot::Sender<u32>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum PendingBackgroundReservation {
+    Prompt,
+    Coalesced,
+    DuplicateHandle,
+}
+
+impl PendingBackgroundResponseRegistry {
+    fn reserve(
+        &mut self,
+        handle: String,
+        app_id: &str,
+        response_sender: oneshot::Sender<u32>,
+    ) -> PendingBackgroundReservation {
+        if self.by_handle.contains_key(&handle) {
+            return PendingBackgroundReservation::DuplicateHandle;
+        }
+
+        let prompt_needed = !self.app_handles.contains_key(app_id);
+        self.by_handle.insert(
+            handle.clone(),
+            PendingBackgroundRequest {
+                app_id: app_id.to_owned(),
+                response_sender,
+            },
+        );
+        self.app_handles
+            .entry(app_id.to_owned())
+            .or_default()
+            .push(handle);
+
+        if prompt_needed {
+            PendingBackgroundReservation::Prompt
+        } else {
+            PendingBackgroundReservation::Coalesced
+        }
+    }
+
+    fn take_app_responses_by_handle(&mut self, handle: &str) -> Vec<oneshot::Sender<u32>> {
+        let Some(app_id) = self
+            .by_handle
+            .get(handle)
+            .map(|request| request.app_id.clone())
+        else {
+            return Vec::new();
+        };
+
+        self.remove_app(&app_id)
+    }
+
+    fn remove_request(&mut self, handle: &str, app_id: &str) {
+        let Some(handles) = self.app_handles.get_mut(app_id) else {
+            self.by_handle.remove(handle);
+            return;
+        };
+
+        let primary_handle = handles.first().is_some_and(|primary| primary == handle);
+        if primary_handle {
+            self.remove_app(app_id);
+            return;
+        }
+
+        handles.retain(|pending_handle| pending_handle != handle);
+        if handles.is_empty() {
+            self.app_handles.remove(app_id);
+        }
+        self.by_handle.remove(handle);
+    }
+
+    fn remove_app(&mut self, app_id: &str) -> Vec<oneshot::Sender<u32>> {
+        let Some(handles) = self.app_handles.remove(app_id) else {
+            return Vec::new();
+        };
+
+        handles
+            .into_iter()
+            .filter_map(|handle| {
+                self.by_handle
+                    .remove(&handle)
+                    .map(|request| request.response_sender)
+            })
+            .collect()
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Type)]
+#[zvariant(signature = "v")]
+#[repr(u32)]
+pub enum AppStatus {
+    Background = 0,
+    Running,
+    // Kept for the Background portal status enum, but currently not reported:
+    // ext-foreign-toplevel-list does not expose activation/focus state.
+    #[allow(dead_code)]
+    Active,
+}
+
+impl Serialize for AppStatus {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        zbus::zvariant::Value::U32(*self as u32).serialize(serializer)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Type, Serialize)]
+#[zvariant(signature = "dict")]
+pub struct NotifyBackgroundResult {
+    #[serde(with = "as_value")]
+    result: u32,
+}
+
+#[interface(name = "org.freedesktop.impl.portal.Background")]
+impl BackgroundBackend {
+    #[zbus(property, name = "version")]
+    fn version(&self) -> u32 {
+        2
+    }
+
+    async fn notify_background(
+        &self,
+        handle: ObjectPath<'_>,
+        app_id: String,
+        name: String,
+        #[zbus(object_server)] server: &zbus::ObjectServer,
+    ) -> fdo::Result<PortalResponse<NotifyBackgroundResult>> {
+        tracing::info!(
+            "Background request: path: {}, appid: {}, name: {}",
+            handle.as_str(),
+            app_id,
+            name
+        );
+
+        match SETTING_CONFIG
+            .lock()
+            .await
+            .background_permission_default
+            .as_str()
+        {
+            "allow" => {
+                return Ok(PortalResponse::Success(NotifyBackgroundResult {
+                    result: 1,
+                }));
+            }
+            "deny" => {
+                return Ok(PortalResponse::Success(NotifyBackgroundResult {
+                    result: 0,
+                }));
+            }
+            _ => {}
+        }
+
+        let handle_path: OwnedObjectPath = handle.clone().into();
+        let handle_name = handle.as_str().to_owned();
+        let app_id_for_cleanup = app_id.clone();
+        let (cancel_sender, mut cancel_receiver) = oneshot::channel();
+        let (response_sender, response_receiver) = oneshot::channel();
+
+        let should_prompt = {
+            let mut pending_responses = self.pending_responses.lock().await;
+            match pending_responses.reserve(handle_name.clone(), &app_id, response_sender) {
+                PendingBackgroundReservation::Prompt => true,
+                PendingBackgroundReservation::Coalesced => false,
+                PendingBackgroundReservation::DuplicateHandle => {
+                    return Err(fdo::Error::InvalidArgs(format!(
+                        "duplicate background request handle: {handle_name}"
+                    )));
+                }
+            }
+        };
+        let close_action = RequestCloseAction {
+            cancel_sender: Arc::new(StdMutex::new(Some(cancel_sender))),
+            ui_sender: self.sender.clone(),
+            close_message: should_prompt.then(|| Message::CloseBackgroundPrompt {
+                handle: handle_name.clone(),
+            }),
+        };
+
+        if let Err(e) = server
+            .at(
+                handle.clone(),
+                RequestInterface {
+                    handle_path: handle_path.clone(),
+                    close_action: Some(close_action),
+                },
+            )
+            .await
+        {
+            self.pending_responses
+                .lock()
+                .await
+                .remove_request(&handle_name, &app_id_for_cleanup);
+            return Err(e.into());
+        }
+
+        let prompt_result = if should_prompt {
+            self.sender
+                .clone()
+                .send(Message::BackgroundPrompt {
+                    handle: handle_name.clone(),
+                    app_id,
+                    name,
+                })
+                .await
+                .map_err(|e| e.to_string())
+        } else {
+            Ok(())
+        };
+        if let Err(e) = prompt_result {
+            self.pending_responses
+                .lock()
+                .await
+                .remove_request(&handle_name, &app_id_for_cleanup);
+            let _ = server
+                .remove::<RequestInterface, &OwnedObjectPath>(&handle_path)
+                .await;
+            return Err(zbus::Error::Failure(e).into());
+        }
+
+        let response = tokio::select! {
+            biased;
+            response = response_receiver => {
+                match response {
+                    Ok(result) => {
+                        Ok(PortalResponse::Success(NotifyBackgroundResult { result }))
+                    }
+                    Err(_) => {
+                        Ok(PortalResponse::Cancelled)
+                    }
+                }
+            }
+            _ = &mut cancel_receiver => {
+                Ok(PortalResponse::Cancelled)
+            }
+        };
+
+        self.pending_responses
+            .lock()
+            .await
+            .remove_request(&handle_name, &app_id_for_cleanup);
+        let _ = server
+            .remove::<RequestInterface, &OwnedObjectPath>(&handle_path)
+            .await;
+
+        response
+    }
+
+    async fn enable_autostart(
+        &self,
+        app_id: String,
+        enable: bool,
+        commandline: Vec<String>,
+        flags: u32,
+    ) -> fdo::Result<bool> {
+        let (autostart_dir, launch_entry) = autostart_paths(&app_id)?;
+
+        if !enable {
+            return match tokio::fs::remove_file(&launch_entry).await {
+                Ok(()) => Ok(false),
+                Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(false),
+                Err(e) => Err(fdo::Error::FileNotFound(format!(
+                    "{e}: ({})",
+                    launch_entry.display()
+                ))),
+            };
+        }
+
+        tokio::fs::create_dir_all(&autostart_dir)
+            .await
+            .map_err(|e| fdo::Error::IOError(format!("{e}: ({})", autostart_dir.display())))?;
+
+        let exec = desktop_exec(&commandline);
+        let desktop_entry =
+            desktop_entry(&app_id, &exec, flags, commandline_is_flatpak(&commandline));
+
+        tokio::fs::write(&launch_entry, desktop_entry)
+            .await
+            .map_err(|e| fdo::Error::IOError(format!("{e}: ({})", launch_entry.display())))?;
+
+        Ok(true)
+    }
+
+    async fn get_app_state(
+        &self,
+        #[zbus(connection)] conn: &zbus::Connection,
+    ) -> fdo::Result<HashMap<String, AppStatus>> {
+        get_app_state_impl(conn).await
+    }
+
+    #[zbus(signal)]
+    pub async fn running_applications_changed(emitter: &SignalEmitter<'_>) -> zbus::Result<()>;
+}
+
+pub async fn route_background_dialog_responses(
+    mut receiver: UnboundedReceiver<CopySelect>,
+    pending_responses: PendingBackgroundResponses,
+) {
+    while let Some(selection) = receiver.next().await {
+        let (handle, result) = match selection {
+            CopySelect::BackgroundPermission { handle, result } => (handle, result),
+            _ => continue,
+        };
+
+        let sender = {
+            let mut pending_responses = pending_responses.lock().await;
+            pending_responses.take_app_responses_by_handle(&handle)
+        };
+
+        if sender.is_empty() {
+            tracing::debug!("Dropping stale background dialog response for {handle}");
+        } else {
+            for sender in sender {
+                let _ = sender.send(result);
+            }
+        }
+    }
+}
+
+fn validate_app_id(app_id: &str) -> fdo::Result<()> {
+    if app_id.is_empty()
+        || app_id.starts_with('.')
+        || app_id.ends_with('.')
+        || !app_id
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'-'))
+    {
+        return Err(fdo::Error::InvalidArgs(format!(
+            "invalid application id: {app_id:?}"
+        )));
+    }
+
+    Ok(())
+}
+
+fn autostart_paths(app_id: &str) -> fdo::Result<(PathBuf, PathBuf)> {
+    validate_app_id(app_id)?;
+
+    let autostart_dir = user_config_dir()?.join("autostart");
+    let launch_entry = autostart_dir.join(format!("{app_id}.desktop"));
+    Ok((autostart_dir, launch_entry))
+}
+
+fn user_config_dir() -> fdo::Result<PathBuf> {
+    if let Some(config_home) = std::env::var_os("XDG_CONFIG_HOME").filter(|value| !value.is_empty())
+    {
+        let config_home = PathBuf::from(config_home);
+        if config_home.is_absolute() {
+            return Ok(config_home);
+        }
+        tracing::warn!(
+            "Ignoring relative XDG_CONFIG_HOME for Background autostart: {}",
+            config_home.display()
+        );
+    }
+
+    let home = std::env::var_os("HOME")
+        .ok_or_else(|| fdo::Error::FileNotFound("XDG_CONFIG_HOME and HOME are not set".into()))?;
+    Ok(PathBuf::from(home).join(".config"))
+}
+
+fn desktop_entry(app_id: &str, exec: &str, flags: u32, flatpak: bool) -> String {
+    let mut entry = String::from("[Desktop Entry]\n");
+
+    push_desktop_entry_string(&mut entry, "Type", "Application");
+    push_desktop_entry_string(&mut entry, "Name", app_id);
+    push_desktop_entry_string(&mut entry, "Exec", exec);
+    if flags & AUTOSTART_DBUS_ACTIVATABLE != 0 {
+        entry.push_str("DBusActivatable=true\n");
+    }
+    if flatpak {
+        push_desktop_entry_string(&mut entry, "X-Flatpak", app_id);
+    }
+    entry
+}
+
+fn push_desktop_entry_string(entry: &mut String, key: &str, value: &str) {
+    entry.push_str(key);
+    entry.push('=');
+    push_desktop_entry_value(entry, value);
+    entry.push('\n');
+}
+
+fn push_desktop_entry_value(entry: &mut String, value: &str) {
+    for ch in value.chars() {
+        match ch {
+            '\\' => entry.push_str("\\\\"),
+            '\n' => entry.push_str("\\n"),
+            '\r' => entry.push_str("\\r"),
+            '\t' => entry.push_str("\\t"),
+            _ => entry.push(ch),
+        }
+    }
+}
+
+fn commandline_is_flatpak(commandline: &[String]) -> bool {
+    commandline
+        .first()
+        .and_then(|command| std::path::Path::new(command).file_name())
+        .is_some_and(|command| command == "flatpak")
+}
+
+fn desktop_exec(commandline: &[String]) -> String {
+    commandline
+        .iter()
+        .map(|term| desktop_exec_arg(term))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn desktop_exec_arg(arg: &str) -> String {
+    let mut needs_quotes = arg.is_empty();
+    let mut escaped = String::with_capacity(arg.len());
+
+    for ch in arg.chars() {
+        if is_desktop_exec_reserved(ch) {
+            needs_quotes = true;
+        }
+
+        match ch {
+            '%' => escaped.push_str("%%"),
+            '"' | '`' | '$' | '\\' => {
+                escaped.push('\\');
+                escaped.push(ch);
+            }
+            _ => escaped.push(ch),
+        }
+    }
+
+    if needs_quotes {
+        format!("\"{escaped}\"")
+    } else {
+        escaped
+    }
+}
+
+fn is_desktop_exec_reserved(ch: char) -> bool {
+    matches!(
+        ch,
+        ' ' | '\t'
+            | '\n'
+            | '"'
+            | '\''
+            | '\\'
+            | '>'
+            | '<'
+            | '~'
+            | '|'
+            | '&'
+            | ';'
+            | '$'
+            | '*'
+            | '?'
+            | '#'
+            | '('
+            | ')'
+            | '`'
+    )
+}
+
+fn merge_app_status(apps: &mut HashMap<String, AppStatus>, app_id: String, status: AppStatus) {
+    apps.entry(app_id)
+        .and_modify(|current| {
+            if status > *current {
+                *current = status;
+            }
+        })
+        .or_insert(status);
+}
+
+fn normalized_app_token(app_id: &str) -> Option<String> {
+    let token = app_id.rsplit('.').next().unwrap_or(app_id);
+    let normalized = token
+        .chars()
+        .filter(|character| character.is_ascii_alphanumeric())
+        .flat_map(|character| character.to_lowercase())
+        .collect::<String>();
+
+    (!normalized.is_empty()).then_some(normalized)
+}
+
+fn app_token_index(app_ids: &[String]) -> HashMap<String, Option<String>> {
+    let mut index = HashMap::new();
+
+    for app_id in app_ids {
+        let Some(token) = normalized_app_token(app_id) else {
+            continue;
+        };
+
+        match index.entry(token) {
+            Entry::Vacant(entry) => {
+                entry.insert(Some(app_id.clone()));
+            }
+            Entry::Occupied(mut entry) if entry.get().as_deref() != Some(app_id.as_str()) => {
+                entry.insert(None);
+            }
+            Entry::Occupied(_) => {}
+        }
+    }
+
+    index
+}
+
+fn fuzzy_systemd_app_id<'a>(
+    wayland_app_id: &str,
+    systemd_app_tokens: &'a HashMap<String, Option<String>>,
+) -> Option<&'a str> {
+    let token = normalized_app_token(wayland_app_id)?;
+    systemd_app_tokens.get(&token)?.as_deref()
+}
+
+pub(crate) async fn get_app_state_impl(
+    conn: &zbus::Connection,
+) -> fdo::Result<HashMap<String, AppStatus>> {
+    let mut apps = HashMap::new();
+    let mut systemd_app_ids = Vec::new();
+    let mut systemd_error = None;
+
+    match Systemd1Proxy::new(conn).await {
+        Ok(proxy) => match proxy.list_units().await {
+            Ok(units) => {
+                for unit in units {
+                    if let Some(app_id) = unit.app_id() {
+                        let app_id = app_id.to_owned();
+                        merge_app_status(&mut apps, app_id.clone(), AppStatus::Background);
+                        systemd_app_ids.push(app_id);
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::warn!("Cannot list systemd app scopes: {e}");
+                systemd_error = Some(e.to_string());
+            }
+        },
+        Err(e) => {
+            tracing::warn!("Cannot connect to systemd manager: {e}");
+            systemd_error = Some(e.to_string());
+        }
+    }
+
+    let systemd_app_tokens = app_token_index(&systemd_app_ids);
+
+    match WayshotConnection::new() {
+        Ok(mut wayshot_connection) => {
+            if let Err(e) = wayshot_connection.refresh_toplevels() {
+                tracing::warn!("Cannot refresh Wayland toplevels: {e:?}");
+            } else {
+                for top_level in wayshot_connection.get_all_toplevels() {
+                    if top_level.app_id.is_empty() {
+                        continue;
+                    }
+
+                    // ext-foreign-toplevel-list reports toplevel presence, but
+                    // not activation/focus state. libwayshot's active flag is
+                    // therefore not meaningful here.
+                    if apps.contains_key(&top_level.app_id) {
+                        merge_app_status(&mut apps, top_level.app_id.clone(), AppStatus::Running);
+                    } else if let Some(systemd_app_id) =
+                        fuzzy_systemd_app_id(&top_level.app_id, &systemd_app_tokens)
+                    {
+                        tracing::debug!(
+                            "Treating Wayland app id {} as systemd app id {}",
+                            top_level.app_id,
+                            systemd_app_id
+                        );
+                        merge_app_status(&mut apps, systemd_app_id.to_owned(), AppStatus::Running);
+                    } else {
+                        merge_app_status(&mut apps, top_level.app_id.clone(), AppStatus::Running);
+                    }
+                }
+            }
+        }
+        Err(e) => {
+            tracing::warn!("Cannot get Wayland toplevels: {e:?}");
+        }
+    }
+
+    if let Some(systemd_error) = systemd_error {
+        tracing::debug!("Returning app state without systemd scope data: {systemd_error}");
+    }
+
+    tracing::debug!("GetAppState is returning {} open apps", apps.len());
+    Ok(apps)
+}
+
+pub fn unit_name_from_systemd_signal(message: &zbus::Message) -> Option<String> {
+    message
+        .body()
+        .deserialize::<(String, zbus::zvariant::OwnedObjectPath)>()
+        .ok()
+        .map(|(unit_name, _)| unit_name)
+}

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -1,4 +1,6 @@
-use iced::futures::channel::mpsc::Sender;
+use std::collections::VecDeque;
+
+use iced::futures::channel::mpsc::{Sender, UnboundedSender};
 use iced::widget::{
     Row, Space, button, checkbox, column, container, grid, image, row, scrollable, text,
 };
@@ -12,6 +14,9 @@ use iced_layershell::to_layer_message;
 
 use libwayshot::output::OutputInfo;
 use libwayshot::region::TopLevel;
+
+const BACKGROUND_PROMPT_QUEUE_CAPACITY: usize = 8;
+const BACKGROUND_PROMPT_TOMBSTONE_CAPACITY: usize = 64;
 
 pub fn dialog(toplevel_capture_support: bool) -> Result<(), iced_layershell::Error> {
     unsafe { std::env::set_var("RUST_LOG", "xdg-desktop-protal-luminous=info") }
@@ -35,13 +40,13 @@ pub fn dialog(toplevel_capture_support: bool) -> Result<(), iced_layershell::Err
     .run()
 }
 
-#[allow(unused)]
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum GuiMode {
     ScreenCast,
     #[default]
     ScreenShot,
     PermissionPrompt,
+    BackgroundPrompt,
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
@@ -57,13 +62,25 @@ struct AreaSelectorGUI {
     gui_mode: GuiMode,
     mode: ViewMode,
     window_show: bool,
+    window_id: Option<iced::window::Id>,
     toplevel_capture_support: bool,
     sender: Option<Sender<CopySelect>>,
     sender_cast: Option<Sender<CopySelect>>,
+    sender_background: Option<UnboundedSender<CopySelect>>,
     toplevels: Vec<TopLevelInfo>,
     screens: Vec<WlOutputInfo>,
     use_cursor: bool,
     prompt_text: Option<String>,
+    active_background_handle: Option<String>,
+    background_queue: VecDeque<BackgroundPromptRequest>,
+    tombstoned_background_handles: VecDeque<String>,
+}
+
+#[derive(Debug, Clone)]
+struct BackgroundPromptRequest {
+    handle: String,
+    app_id: String,
+    name: String,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -74,6 +91,7 @@ pub enum CopySelect {
     Slurp,
     Cancel,
     Permission(bool),
+    BackgroundPermission { handle: String, result: u32 },
 }
 
 #[derive(Debug, Clone)]
@@ -114,8 +132,17 @@ pub enum Message {
     ShowModeChange(ShowMode),
     ReadyShoot(Sender<CopySelect>),
     ReadyCast(Sender<CopySelect>),
+    ReadyBackground(UnboundedSender<CopySelect>),
     ToggleCursor(bool),
     PermissionDialog(String),
+    BackgroundPrompt {
+        handle: String,
+        app_id: String,
+        name: String,
+    },
+    CloseBackgroundPrompt {
+        handle: String,
+    },
 }
 
 impl AreaSelectorGUI {
@@ -228,18 +255,124 @@ impl AreaSelectorGUI {
             gui_mode: GuiMode::ScreenShot,
             mode: ViewMode::Others,
             window_show: false,
+            window_id: None,
             toplevel_capture_support,
             sender: None,
             sender_cast: None,
+            sender_background: None,
             toplevels: Vec::new(),
             screens: Vec::new(),
             use_cursor: false,
             prompt_text: None,
+            active_background_handle: None,
+            background_queue: VecDeque::new(),
+            tombstoned_background_handles: VecDeque::new(),
         }
     }
 
     fn namespace() -> String {
         String::from("osk")
+    }
+
+    fn open_background_prompt(
+        &mut self,
+        handle: String,
+        app_id: String,
+        name: String,
+    ) -> Task<Message> {
+        self.window_show = true;
+        self.gui_mode = GuiMode::BackgroundPrompt;
+        self.active_background_handle = Some(handle);
+        let app_name = if name.is_empty() { app_id } else { name };
+        self.prompt_text = Some(format!(
+            "Allow '{}' to keep running in the background?",
+            app_name
+        ));
+        let id = iced::window::Id::unique();
+        self.window_id = Some(id);
+        Task::done(Message::NewLayerShell {
+            settings: NewLayerShellSettings {
+                size: Some((360, 128)),
+                anchor: Anchor::Top | Anchor::Bottom,
+                keyboard_interactivity: KeyboardInteractivity::OnDemand,
+                output_option: OutputOption::None,
+                ..Default::default()
+            },
+            id,
+        })
+    }
+
+    fn show_next_background_prompt(&mut self) -> Task<Message> {
+        if self.window_show {
+            return Task::none();
+        }
+
+        let Some(request) = self.background_queue.pop_front() else {
+            return Task::none();
+        };
+
+        self.open_background_prompt(request.handle, request.app_id, request.name)
+    }
+
+    fn send_background_response(&self, select: CopySelect) {
+        let CopySelect::BackgroundPermission { handle, result } = &select else {
+            return;
+        };
+        let handle = handle.clone();
+        let result = *result;
+
+        let Some(sender) = &self.sender_background else {
+            tracing::warn!(
+                "Cannot deliver background permission result {result} for {handle}: response channel is not ready"
+            );
+            return;
+        };
+
+        if let Err(e) = sender.unbounded_send(select) {
+            tracing::warn!(
+                "Cannot deliver background permission result {result} for {handle}: receiver is gone: {e}"
+            );
+        }
+    }
+
+    fn tombstone_background_handle(&mut self, handle: String) {
+        if self
+            .tombstoned_background_handles
+            .iter()
+            .any(|tombstone| tombstone == &handle)
+        {
+            return;
+        }
+
+        if self.tombstoned_background_handles.len() >= BACKGROUND_PROMPT_TOMBSTONE_CAPACITY {
+            self.tombstoned_background_handles.pop_front();
+        }
+        self.tombstoned_background_handles.push_back(handle);
+    }
+
+    fn consume_background_tombstone(&mut self, handle: &str) -> bool {
+        let Some(index) = self
+            .tombstoned_background_handles
+            .iter()
+            .position(|tombstone| tombstone == handle)
+        else {
+            return false;
+        };
+
+        self.tombstoned_background_handles.remove(index);
+        true
+    }
+
+    fn close_window_and_show_next_background_prompt(
+        &mut self,
+        id: iced::window::Id,
+    ) -> Task<Message> {
+        use iced_runtime::Action;
+        use iced_runtime::window::Action as WindowAction;
+
+        let close_task = iced_runtime::task::effect(Action::Window(WindowAction::Close(id)));
+        let next_prompt_task = self.show_next_background_prompt();
+        Task::batch([close_task, next_prompt_task])
     }
 
     fn update(&mut self, message: Message) -> Task<Message> {
@@ -257,19 +390,38 @@ impl AreaSelectorGUI {
                 Task::none()
             }
             Message::Selected { id, select } => {
-                use iced_runtime::Action;
-                use iced_runtime::window::Action as WindowAction;
+                if self.window_id != Some(id) {
+                    return Task::none();
+                }
+
                 match self.gui_mode {
                     GuiMode::ScreenCast => {
                         let _ = self.sender_cast.as_mut().unwrap().try_send(select);
                     }
+                    GuiMode::BackgroundPrompt => match &select {
+                        CopySelect::BackgroundPermission { handle, .. }
+                            if self.active_background_handle.as_ref() == Some(handle) =>
+                        {
+                            self.send_background_response(select);
+                        }
+                        _ => return Task::none(),
+                    },
                     GuiMode::ScreenShot | GuiMode::PermissionPrompt => {
+                        if matches!(select, CopySelect::BackgroundPermission { .. }) {
+                            return Task::none();
+                        }
                         let _ = self.sender.as_mut().unwrap().try_send(select);
                     }
                 }
 
                 self.window_show = false;
-                iced_runtime::task::effect(Action::Window(WindowAction::Close(id)))
+                self.window_id = None;
+                if self.gui_mode == GuiMode::BackgroundPrompt {
+                    self.gui_mode = GuiMode::ScreenShot;
+                    self.prompt_text = None;
+                    self.active_background_handle = None;
+                }
+                self.close_window_and_show_next_background_prompt(id)
             }
 
             Message::ImageCopyOpen {
@@ -287,6 +439,8 @@ impl AreaSelectorGUI {
                 self.window_show = true;
                 self.toplevels = toplevels;
                 self.screens = screens;
+                let id = iced::window::Id::unique();
+                self.window_id = Some(id);
                 Task::done(Message::NewLayerShell {
                     settings: NewLayerShellSettings {
                         exclusive_zone: None,
@@ -296,7 +450,7 @@ impl AreaSelectorGUI {
                         output_option: OutputOption::None,
                         ..Default::default()
                     },
-                    id: iced::window::Id::unique(),
+                    id,
                 })
             }
             Message::ScreenCastOpen {
@@ -320,6 +474,8 @@ impl AreaSelectorGUI {
                 self.window_show = true;
                 self.toplevels = toplevels;
                 self.screens = screens;
+                let id = iced::window::Id::unique();
+                self.window_id = Some(id);
                 Task::done(Message::NewLayerShell {
                     settings: NewLayerShellSettings {
                         exclusive_zone: None,
@@ -329,7 +485,7 @@ impl AreaSelectorGUI {
                         output_option: OutputOption::None,
                         ..Default::default()
                     },
-                    id: iced::window::Id::unique(),
+                    id,
                 })
             }
             Message::ReadyShoot(sender) => {
@@ -338,6 +494,10 @@ impl AreaSelectorGUI {
             }
             Message::ReadyCast(sender) => {
                 self.sender_cast = Some(sender);
+                Task::none()
+            }
+            Message::ReadyBackground(sender) => {
+                self.sender_background = Some(sender);
                 Task::none()
             }
             Message::ToggleCursor(cursor) => {
@@ -352,6 +512,8 @@ impl AreaSelectorGUI {
                 self.window_show = true;
                 self.gui_mode = GuiMode::PermissionPrompt;
                 self.prompt_text = Some(message);
+                let id = iced::window::Id::unique();
+                self.window_id = Some(id);
                 Task::done(Message::NewLayerShell {
                     settings: NewLayerShellSettings {
                         size: Some((256, 100)),
@@ -360,8 +522,58 @@ impl AreaSelectorGUI {
                         output_option: OutputOption::None,
                         ..Default::default()
                     },
-                    id: iced::window::Id::unique(),
+                    id,
                 })
+            }
+            Message::BackgroundPrompt {
+                handle,
+                app_id,
+                name,
+            } => {
+                if self.consume_background_tombstone(&handle) {
+                    return Task::none();
+                }
+
+                if self.window_show {
+                    if self.background_queue.len() >= BACKGROUND_PROMPT_QUEUE_CAPACITY {
+                        self.send_background_response(CopySelect::BackgroundPermission {
+                            handle,
+                            result: 2,
+                        });
+                    } else {
+                        self.background_queue.push_back(BackgroundPromptRequest {
+                            handle,
+                            app_id,
+                            name,
+                        });
+                    }
+                    return Task::none();
+                }
+                self.open_background_prompt(handle, app_id, name)
+            }
+            Message::CloseBackgroundPrompt { handle } => {
+                if self.gui_mode != GuiMode::BackgroundPrompt
+                    || self.active_background_handle.as_ref() != Some(&handle)
+                {
+                    let previous_queue_len = self.background_queue.len();
+                    self.background_queue
+                        .retain(|request| request.handle != handle);
+                    if self.background_queue.len() == previous_queue_len {
+                        self.tombstone_background_handle(handle);
+                    }
+                    return Task::none();
+                }
+
+                self.window_show = false;
+                self.gui_mode = GuiMode::ScreenShot;
+                self.prompt_text = None;
+                self.active_background_handle = None;
+
+                if let Some(id) = self.window_id.take() {
+                    self.close_window_and_show_next_background_prompt(id)
+                } else {
+                    self.show_next_background_prompt()
+                }
             }
             _ => unreachable!(),
         }
@@ -398,9 +610,57 @@ impl AreaSelectorGUI {
         .into()
     }
 
+    fn view_background_prompt(&self, id: iced::window::Id) -> Element<'_, Message> {
+        let handle = self.active_background_handle.clone().unwrap_or_default();
+
+        column![
+            container(text(self.prompt_text.as_ref().unwrap()))
+                .center_x(Length::Fill)
+                .center_y(Length::Fill)
+                .height(Length::Fill),
+            Space::new().height(Length::Fill),
+            row![
+                button("Allow")
+                    .on_press(Message::Selected {
+                        id,
+                        select: CopySelect::BackgroundPermission {
+                            handle: handle.clone(),
+                            result: 1
+                        }
+                    })
+                    .width(Length::Fill),
+                button("Allow once")
+                    .on_press(Message::Selected {
+                        id,
+                        select: CopySelect::BackgroundPermission {
+                            handle: handle.clone(),
+                            result: 2
+                        }
+                    })
+                    .width(Length::Fill),
+                button("Deny")
+                    .style(button::text)
+                    .on_press(Message::Selected {
+                        id,
+                        select: CopySelect::BackgroundPermission { handle, result: 0 }
+                    })
+                    .width(Length::Fill),
+            ]
+            .padding(2.)
+            .spacing(5.)
+            .width(Length::Fill)
+        ]
+        .width(Length::Fill)
+        .height(Length::Fill)
+        .into()
+    }
+
     fn view(&self, id: iced::window::Id) -> Element<'_, Message> {
         if self.gui_mode == GuiMode::PermissionPrompt {
             return self.view_permission_prompt(id);
+        }
+        if self.gui_mode == GuiMode::BackgroundPrompt {
+            return self.view_background_prompt(id);
         }
 
         let selector = self.selector();
@@ -493,19 +753,26 @@ impl AreaSelectorGUI {
     fn subscription(&self) -> iced::Subscription<Message> {
         iced::Subscription::run(|| {
             iced::stream::channel(100, |mut output: Sender<Message>| async move {
-                use iced::futures::channel::mpsc::channel;
+                use iced::futures::channel::mpsc::{channel, unbounded};
                 use iced::futures::sink::SinkExt;
                 let (sender, receiver) = channel(100);
                 let (sender_cast, receiver_cast) = channel(100);
+                let (sender_background, receiver_background) = unbounded();
                 let _ = output.send(Message::ReadyShoot(sender)).await;
                 let _ = output.send(Message::ReadyCast(sender_cast)).await;
+                let _ = output
+                    .send(Message::ReadyBackground(sender_background))
+                    .await;
 
-                let _ = crate::backend::backend(output, receiver, receiver_cast).await;
+                let _ =
+                    crate::backend::backend(output, receiver, receiver_cast, receiver_background)
+                        .await;
             })
         })
     }
     fn theme(&self, _id: iced::window::Id) -> Option<iced::Theme> {
-        if self.gui_mode == GuiMode::PermissionPrompt {
+        if self.gui_mode == GuiMode::PermissionPrompt || self.gui_mode == GuiMode::BackgroundPrompt
+        {
             return Some(iced::Theme::TokyoNight);
         }
         None

--- a/src/input_capture.rs
+++ b/src/input_capture.rs
@@ -166,6 +166,7 @@ impl InputCapture {
                 handle.clone(),
                 RequestInterface {
                     handle_path: handle.clone().into(),
+                    close_action: None,
                 },
             )
             .await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod access;
 mod backend;
+mod background;
 mod dialog;
 mod input_capture;
 mod remotedesktop;
@@ -8,6 +9,7 @@ mod screencast;
 mod screenshot;
 mod session;
 mod settings;
+mod systemd;
 mod utils;
 
 use std::collections::HashMap;

--- a/src/remotedesktop.rs
+++ b/src/remotedesktop.rs
@@ -376,6 +376,7 @@ impl RemoteDesktopBackend {
                 request_handle.clone(),
                 RequestInterface {
                     handle_path: request_handle.clone().into(),
+                    close_action: None,
                 },
             )
             .await?;

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,7 +1,20 @@
+use std::sync::{Arc, Mutex};
+
+use futures::{SinkExt, channel::mpsc::Sender};
+use tokio::sync::oneshot;
 use zbus::{interface, zvariant::OwnedObjectPath};
+
+use crate::dialog::Message;
+
+pub struct RequestCloseAction {
+    pub cancel_sender: Arc<Mutex<Option<oneshot::Sender<()>>>>,
+    pub ui_sender: Sender<Message>,
+    pub close_message: Option<Message>,
+}
 
 pub struct RequestInterface {
     pub handle_path: OwnedObjectPath,
+    pub close_action: Option<RequestCloseAction>,
 }
 
 #[interface(name = "org.freedesktop.impl.portal.Request")]
@@ -10,6 +23,23 @@ impl RequestInterface {
         &self,
         #[zbus(object_server)] server: &zbus::ObjectServer,
     ) -> zbus::fdo::Result<()> {
+        if let Some(action) = &self.close_action {
+            let cancel_sender = action
+                .cancel_sender
+                .lock()
+                .ok()
+                .and_then(|mut sender| sender.take());
+
+            if let Some(cancel_sender) = cancel_sender {
+                let _ = cancel_sender.send(());
+            }
+
+            if let Some(close_message) = &action.close_message {
+                let mut ui_sender = action.ui_sender.clone();
+                let _ = ui_sender.send(close_message.clone()).await;
+            }
+        }
+
         server
             .remove::<Self, &OwnedObjectPath>(&self.handle_path)
             .await?;

--- a/src/screencast.rs
+++ b/src/screencast.rs
@@ -162,6 +162,7 @@ impl ScreenCastBackend {
                 request_handle.clone(),
                 RequestInterface {
                     handle_path: request_handle.clone().into(),
+                    close_action: None,
                 },
             )
             .await?;

--- a/src/screenshot.rs
+++ b/src/screenshot.rs
@@ -168,7 +168,9 @@ impl ScreenShotBackend {
                 CopySelect::Cancel => {
                     return Ok(PortalResponse::Cancelled);
                 }
-                CopySelect::Permission(_) => unreachable!(),
+                CopySelect::Permission(_) | CopySelect::BackgroundPermission { .. } => {
+                    unreachable!()
+                }
             }
         } else {
             wayshot_connection

--- a/src/settings/config.rs
+++ b/src/settings/config.rs
@@ -11,6 +11,7 @@ const HIGHER_CONTRAST: &str = "higher";
 
 const DEFAULT_REDUCED_MOTION: &str = "default";
 const REDUCED_REDUCED_MOTION: &str = "reduced";
+const DEFAULT_BACKGROUND_PERMISSION: &str = "ask";
 
 #[derive(Deserialize, PartialEq, Eq, Debug)]
 pub struct SettingsConfig {
@@ -19,6 +20,7 @@ pub struct SettingsConfig {
     pub contrast: String,
     pub reduced_motion: String,
     pub screenshot_permission_check: bool,
+    pub background_permission_default: String,
 }
 
 #[derive(Deserialize, PartialEq, Eq, Debug)]
@@ -28,6 +30,7 @@ struct SettingsConfigRead {
     pub contrast: Option<String>,
     pub reduced_motion: Option<String>,
     pub screenshot_permission_check: Option<bool>,
+    pub background_permission_default: Option<String>,
 }
 
 impl From<SettingsConfigRead> for SettingsConfig {
@@ -42,6 +45,15 @@ impl From<SettingsConfigRead> for SettingsConfig {
                 .reduced_motion
                 .unwrap_or(DEFAULT_REDUCED_MOTION.to_string()),
             screenshot_permission_check: value.screenshot_permission_check.unwrap_or(true),
+            background_permission_default: match value
+                .background_permission_default
+                .unwrap_or(DEFAULT_BACKGROUND_PERMISSION.to_string())
+                .as_str()
+            {
+                "allow" => "allow".to_string(),
+                "deny" => "deny".to_string(),
+                _ => DEFAULT_BACKGROUND_PERMISSION.to_string(),
+            },
         }
     }
 }
@@ -93,6 +105,7 @@ impl Default for SettingsConfig {
             contrast: DEFAULT_CONTRAST.to_string(),
             reduced_motion: DEFAULT_REDUCED_MOTION.to_string(),
             screenshot_permission_check: true,
+            background_permission_default: DEFAULT_BACKGROUND_PERMISSION.to_string(),
         }
     }
 }

--- a/src/systemd.rs
+++ b/src/systemd.rs
@@ -1,0 +1,68 @@
+use serde::Deserialize;
+use zbus::{Result, zvariant};
+
+const APP_SCOPE_PREFIX: &str = "app-";
+const SCOPE_SUFFIX: &str = ".scope";
+const KNOWN_LAUNCHERS: &[&str] = &["flatpak"];
+
+#[zbus::proxy(
+    default_service = "org.freedesktop.systemd1",
+    default_path = "/org/freedesktop/systemd1",
+    interface = "org.freedesktop.systemd1.Manager"
+)]
+pub trait Systemd1 {
+    fn list_units(&self) -> Result<Vec<Unit>>;
+    fn subscribe(&self) -> Result<()>;
+
+    #[zbus(signal)]
+    fn unit_new(&self, id: &str, unit: zvariant::OwnedObjectPath) -> Result<()>;
+
+    #[zbus(signal)]
+    fn unit_removed(&self, id: &str, unit: zvariant::OwnedObjectPath) -> Result<()>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, zvariant::Type)]
+#[zvariant(signature = "(ssssssouso)")]
+pub struct Unit {
+    pub name: String,
+    pub description: String,
+    pub load_state: String,
+    pub active_state: String,
+    pub sub_state: String,
+    pub following: String,
+    pub unit_object: zvariant::OwnedObjectPath,
+    pub job_id: u32,
+    pub job_type: String,
+    pub job_object: zvariant::OwnedObjectPath,
+}
+
+impl Unit {
+    pub fn app_id(&self) -> Option<&str> {
+        parse_app_scope_name(&self.name)
+    }
+}
+
+pub fn parse_app_scope_name(unit_name: &str) -> Option<&str> {
+    let without_prefix = unit_name.strip_prefix(APP_SCOPE_PREFIX)?;
+    let mut without_suffix = without_prefix.strip_suffix(SCOPE_SUFFIX)?;
+    without_suffix = KNOWN_LAUNCHERS
+        .iter()
+        .find_map(|launcher| without_suffix.strip_prefix(&format!("{launcher}-")))
+        .unwrap_or(without_suffix);
+
+    let (app_id, suffix) = without_suffix.rsplit_once('-')?;
+    if app_id.is_empty() || !is_generated_scope_suffix(suffix) {
+        return None;
+    }
+
+    Some(app_id)
+}
+
+fn is_generated_scope_suffix(suffix: &str) -> bool {
+    !suffix.is_empty()
+        && (suffix.bytes().all(|b| b.is_ascii_digit())
+            || suffix.len() >= 4
+                && suffix
+                    .bytes()
+                    .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit()))
+}


### PR DESCRIPTION
Implements the Background portal by tracking user systemd transient app scopes `(app-<launcher>-<app_id>-<suffix>.scope)` and listening for `UnitNew/UnitRemoved` to follow app lifecycle changes. Wayland toplevels from libwayshot are used to detect which scoped apps have visible windows. When the systemd app ID and window app ID differ, the code compares the final app-name part so cases like `com.github.wwmm.easyeffects` and `org.kde.easyeffects` are treated as the same app. Background prompts run asynchronously, queue behind the single layershell dialog, and queue overflow returns allow once instead of deny.