### PR TITLE
Document Background Autostart Requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,27 @@ default=luminous
 org.freedesktop.impl.portal.Settings=luminous;gtk
 ```
 
+# Background autostart:
+
+Applications that use `org.freedesktop.portal.Background.RequestBackground` can be autostarted by `xdg-desktop-portal`: when the request is granted, the frontend writes an XDG autostart desktop entry, which `systemd-xdg-autostart-generator` turns into an `app-*@autostart.service` unit on the next login.
+
+Native apps have a bootstrap requirement before that can happen: the first `RequestBackground` call must come from a process whose application ID the portal frontend can identify. Flatpak and snap apps provide this through sandbox metadata, but native apps normally need to be launched by a session or launcher that puts them in an `app-*` systemd scope or service. uwsm or a one-off `systemd-run --user --scope --unit=app-...scope ...` command can provide that scope. A bare native launch cannot be granted background autostart, so no portal-written autostart entry is created.
+
+Generated autostart units only run if the session starts `xdg-desktop-autostart.target`, or a compositor-specific wrapper target that starts it. Some wlroots sessions do not do this by default. For example, a Sway session can start its wrapper target from the compositor config:
+
+```conf
+exec systemctl --user start sway-xdg-autostart.target
+```
+
+Non-Flatpak apps have one more requirement: their `Exec=` command must be resolvable by the systemd user manager. A bare command such as `Exec=MyApp` is silently skipped by `systemd-xdg-autostart-generator` when the binary lives outside the manager's `PATH` (for example in `~/.local/bin`, which the user manager does not include by default). The app itself can avoid this by passing an absolute command to `RequestBackground`; a user can instead add the directory to the user manager environment (hand-editing the generated entry does not stick, since the portal rewrites it on the app's next request):
+
+```ini
+# ~/.config/environment.d/10-local-bin.conf
+PATH=${HOME}/.local/bin:${PATH}
+```
+
+After changing `environment.d`, log out and back in or reboot so the user manager re-runs its generators and the autostart target starts the generated unit. `systemctl --user daemon-reload` re-runs the generators too, but it does not start a newly generated autostart unit; start that unit or restart the autostart target if you want to test it in the current session.
+
 # Future goals:
 
 * Do not rely on slurp binary. We feel calling binaries is a hack to achieve some end goal, it is almost always better to programmatically invoke the given API.


### PR DESCRIPTION
I tested this locally with SyncThingy, which calls the `RequestBackground` API. After following these requirements, the app is granted background autostart and correctly starts again after reboot/login.
