### PR TITLE
Implement Clipboard Portal for RemoteDesktop Sessions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ rustix = { version = "1.1.4", features = ["fs", "use-libc"] }
 wayland-protocols = { version = "0.32.13", default-features = false, features = [
 	"unstable",
 	"client",
+	"staging",
 ] }
 
 wayland-protocols-wlr = { version = "0.3.12", default-features = false, features = [

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -1,67 +1,78 @@
 mod wayland_backend;
+
 use std::{
     collections::HashMap,
     sync::{Arc, LazyLock},
+    time::Duration,
 };
 
 use serde::{Deserialize, Serialize};
+use tokio::sync::{Mutex, mpsc, oneshot, watch};
 use zbus::{
     interface,
     object_server::SignalEmitter,
-    zvariant::{Fd, ObjectPath, OwnedObjectPath, OwnedValue, Type, Value, as_value},
+    zvariant::{
+        Fd, ObjectPath, OwnedObjectPath, OwnedValue, Type,
+        as_value::{self, optional},
+    },
 };
 
-use crate::{
-    clipboard::wayland_backend::ClipboardRequest,
-    request::RequestInterface,
-    session::{Session, SessionType, append_session},
-};
-use tokio::sync::Mutex;
+use crate::session::{SESSIONS, SessionType};
+use wayland_backend::{ClipboardRequest, ClipboardThread, OwnerState, TransferEvent};
 
-use wayland_backend::ClipboardThread;
+const SIGNAL_QUEUE_DEPTH: usize = 64;
+const INIT_TIMEOUT: Duration = Duration::from_secs(5);
+const WORKER_REPLY_TIMEOUT: Duration = Duration::from_secs(1);
 
-pub static CLIPBOARD_SESSION: LazyLock<Arc<Mutex<HashMap<OwnedObjectPath, ClipboardThread>>>> =
+static CLIPBOARD_SESSION: LazyLock<Arc<Mutex<HashMap<OwnedObjectPath, ClipboardEntry>>>> =
     LazyLock::new(|| Arc::new(Mutex::new(HashMap::new())));
 
-pub async fn append_clipboard_session(object_path: ObjectPath<'_>, thread: ClipboardThread) {
-    let mut sessions = CLIPBOARD_SESSION.lock().await;
-    if let Some(thread) = sessions.insert(object_path.into(), thread) {
-        thread.stop();
-    }
+struct ForwarderParts {
+    emitter: SignalEmitter<'static>,
+    transfer_rx: mpsc::Receiver<TransferEvent>,
+    owner_rx: watch::Receiver<Option<OwnerState>>,
 }
 
-pub async fn remove_clipboard_session(object_path: ObjectPath<'_>) {
-    let mut sessions = CLIPBOARD_SESSION.lock().await;
-    let Some(thread) = sessions.remove(&object_path) else {
-        return;
-    };
-    thread.stop();
-    tracing::info!("session {} is stopped", object_path);
+struct ClipboardEntry {
+    thread: ClipboardThread,
+    forwarder: Option<ForwarderParts>,
 }
 
-#[derive(Debug, Serialize, Type, Deserialize)]
+#[derive(Debug, Default, Deserialize, Type)]
 #[zvariant(signature = "dict")]
-struct SelectionOpt {
-    #[serde(with = "as_value")]
-    mime_types: Vec<String>,
-    #[serde(with = "as_value")]
-    session_handle: OwnedObjectPath,
-    #[serde(flatten)]
-    options_rest: HashMap<String, OwnedValue>,
+struct SetSelectionOptions {
+    #[serde(with = "optional", skip_serializing_if = "Option::is_none", default)]
+    mime_types: Option<Vec<String>>,
 }
 
 #[derive(Debug, Type, Serialize)]
 #[zvariant(signature = "dict")]
-struct OwnerChanged<'a> {
+struct SelectionOwnerChangedOptions {
     #[serde(with = "as_value")]
-    mime_types: Vec<&'a str>,
+    mime_types: Vec<String>,
     #[serde(with = "as_value")]
     session_is_owner: bool,
 }
 
 pub struct Clipboard;
 
-#[interface(name = "org.freedesktop.impl.portal.Clipboard")]
+fn request_failed(message: impl Into<String>) -> zbus::fdo::Error {
+    zbus::fdo::Error::Failed(message.into())
+}
+
+async fn clipboard_sender(
+    session_handle: &ObjectPath<'_>,
+) -> zbus::fdo::Result<calloop::channel::SyncSender<ClipboardRequest>> {
+    let sessions = CLIPBOARD_SESSION.lock().await;
+    sessions
+        .get(session_handle)
+        .map(|entry| entry.thread.sender.clone())
+        .ok_or_else(|| request_failed(format!("no such path: {session_handle}")))
+}
+
+// NOTE: spawn = false keeps handlers in receive order (RequestClipboard must land before
+// Start reads the flag); in exchange every worker await is bounded by WORKER_REPLY_TIMEOUT.
+#[interface(name = "org.freedesktop.impl.portal.Clipboard", spawn = false)]
 impl Clipboard {
     #[zbus(property, name = "version")]
     fn version(&self) -> u32 {
@@ -71,43 +82,35 @@ impl Clipboard {
     async fn request_clipboard(
         &self,
         session_handle: ObjectPath<'_>,
-        _options: HashMap<&'_ str, Value<'_>>,
-        #[zbus(object_server)] server: &zbus::ObjectServer,
+        _options: HashMap<String, OwnedValue>,
     ) -> zbus::fdo::Result<()> {
-        tracing::info!("Start clipboard: path :{}", session_handle.as_str(),);
-        server
-            .at(
-                session_handle.clone(),
-                RequestInterface {
-                    handle_path: session_handle.clone().into(),
-                    close_action: None,
-                },
-            )
-            .await?;
-        let current_session = Session::new(session_handle.clone(), SessionType::Clipboard);
-        append_session(current_session.clone()).await;
-        let clipboard_thread = ClipboardThread::new();
-        append_clipboard_session(session_handle, clipboard_thread).await;
+        let mut sessions = SESSIONS.lock().await;
+        let Some(session) = sessions
+            .iter_mut()
+            .find(|session| session.handle_path == session_handle.clone().into())
+        else {
+            return Err(request_failed(format!("no session {session_handle}")));
+        };
+        if session.session_type != SessionType::Remote {
+            return Err(request_failed(
+                "clipboard requires a remote desktop session",
+            ));
+        }
+        session.clipboard_requested = true;
         Ok(())
     }
 
     async fn set_selection(
         &self,
         session_handle: ObjectPath<'_>,
-        options: SelectionOpt,
+        options: SetSelectionOptions,
     ) -> zbus::fdo::Result<()> {
-        let sessions = CLIPBOARD_SESSION.lock().await;
-        let Some(thread) = sessions.get(&session_handle) else {
-            return Err(zbus::fdo::Error::Failed(format!(
-                "no such path: {session_handle}"
-            )));
-        };
-        thread
-            .sender
-            .send(ClipboardRequest::SetSelection {
-                mime_types: options.mime_types,
+        let sender = clipboard_sender(&session_handle).await?;
+        sender
+            .try_send(ClipboardRequest::SetSelection {
+                mime_types: options.mime_types.unwrap_or_default(),
             })
-            .map_err(|e| zbus::fdo::Error::Failed(format!("request selection failed: {e}")))?;
+            .map_err(|error| request_failed(format!("request selection failed: {error}")))?;
         Ok(())
     }
 
@@ -115,72 +118,238 @@ impl Clipboard {
         &self,
         session_handle: ObjectPath<'_>,
         serial: u32,
-        #[zbus(signal_emitter)] ctx: SignalEmitter<'_>,
     ) -> zbus::fdo::Result<Fd<'_>> {
-        let sessions = CLIPBOARD_SESSION.lock().await;
-        let Some(thread) = sessions.get(&session_handle) else {
-            return Err(zbus::fdo::Error::Failed(format!(
-                "no such path: {session_handle}"
-            )));
-        };
-        let (sender, receiver) = tokio::sync::oneshot::channel();
-        thread
-            .sender
-            .send(ClipboardRequest::Write { sender, serial })
-            .map_err(|e| zbus::fdo::Error::Failed(format!("request selection failed: {e}")))?;
-        let (fd, mime_type) = receiver
+        let sender = clipboard_sender(&session_handle).await?;
+        let (reply_tx, reply_rx) = oneshot::channel();
+        sender
+            .try_send(ClipboardRequest::Write {
+                serial,
+                sender: reply_tx,
+            })
+            .map_err(|error| request_failed(format!("request selection failed: {error}")))?;
+        // NOTE: a timed-out reply_rx is safe to drop; the late send fails and closes the fd
+        let fd = tokio::time::timeout(WORKER_REPLY_TIMEOUT, reply_rx)
             .await
-            .map_err(|e| zbus::fdo::Error::Failed(format!("request selection failed: {e}")))?;
-        let _ = Self::session_transfer(&ctx, mime_type.as_str(), serial).await;
+            .map_err(|_| request_failed("clipboard worker did not reply in time"))?
+            .map_err(|error| request_failed(format!("clipboard worker stopped: {error}")))?
+            .map_err(request_failed)?;
         Ok(Fd::from(fd))
     }
 
     async fn selection_write_done(
         &self,
-        _session_handle: ObjectPath<'_>,
-        _serial: u32,
-        _success: bool,
+        session_handle: ObjectPath<'_>,
+        serial: u32,
+        success: bool,
     ) -> zbus::fdo::Result<()> {
-        // TODO: what to do here?
-        Ok(())
+        let sender = clipboard_sender(&session_handle).await?;
+        let (reply_tx, reply_rx) = oneshot::channel();
+        sender
+            .try_send(ClipboardRequest::WriteDone {
+                serial,
+                success,
+                sender: reply_tx,
+            })
+            .map_err(|error| request_failed(format!("request selection failed: {error}")))?;
+        tokio::time::timeout(WORKER_REPLY_TIMEOUT, reply_rx)
+            .await
+            .map_err(|_| request_failed("clipboard worker did not reply in time"))?
+            .map_err(|error| request_failed(format!("clipboard worker stopped: {error}")))?
+            .map_err(request_failed)
     }
 
     async fn selection_read(
         &self,
         session_handle: ObjectPath<'_>,
-        mime_type: &'_ str,
+        mime_type: &str,
     ) -> zbus::fdo::Result<Fd<'_>> {
-        let sessions = CLIPBOARD_SESSION.lock().await;
-        let Some(thread) = sessions.get(&session_handle) else {
-            return Err(zbus::fdo::Error::Failed(format!(
-                "no such path: {session_handle}"
-            )));
-        };
-        let (sender, receiver) = tokio::sync::oneshot::channel();
-        thread
-            .sender
-            .send(ClipboardRequest::Read {
-                sender,
+        let sender = clipboard_sender(&session_handle).await?;
+        let (reply_tx, reply_rx) = oneshot::channel();
+        sender
+            .try_send(ClipboardRequest::Read {
                 mime_type: mime_type.to_owned(),
+                sender: reply_tx,
             })
-            .map_err(|e| zbus::fdo::Error::Failed(format!("request selection failed: {e}")))?;
-        let fd = receiver
+            .map_err(|error| request_failed(format!("request selection failed: {error}")))?;
+        let fd = tokio::time::timeout(WORKER_REPLY_TIMEOUT, reply_rx)
             .await
-            .map_err(|e| zbus::fdo::Error::Failed(format!("request selection failed: {e}")))?;
+            .map_err(|_| request_failed("clipboard worker did not reply in time"))?
+            .map_err(|error| request_failed(format!("clipboard worker stopped: {error}")))?
+            .map_err(request_failed)?;
         Ok(Fd::from(fd))
     }
 
-    #[zbus(signal)]
-    async fn session_owner_changed(
+    #[zbus(signal, name = "SelectionOwnerChanged")]
+    async fn selection_owner_changed(
         signal_ctx: &SignalEmitter<'_>,
         session_handle: ObjectPath<'_>,
-        options: OwnerChanged<'_>,
+        options: SelectionOwnerChangedOptions,
     ) -> zbus::Result<()>;
 
-    #[zbus(signal)]
-    async fn session_transfer(
+    #[zbus(signal, name = "SelectionTransfer")]
+    async fn selection_transfer(
         signal_ctx: &SignalEmitter<'_>,
-        mime_type: &'_ str,
+        session_handle: ObjectPath<'_>,
+        mime_type: &str,
         serial: u32,
     ) -> zbus::Result<()>;
+}
+
+pub(crate) async fn ensure_clipboard_session(
+    session_handle: &ObjectPath<'_>,
+    connection: zbus::Connection,
+) -> bool {
+    let key: OwnedObjectPath = session_handle.to_owned().into();
+    {
+        let sessions_guard = SESSIONS.lock().await;
+        if !sessions_guard
+            .iter()
+            .any(|session| session.handle_path == key)
+        {
+            return false;
+        }
+    }
+
+    let (transfer_tx, transfer_rx) = mpsc::channel(SIGNAL_QUEUE_DEPTH);
+    let (owner_tx, owner_rx) = watch::channel(None);
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let thread = match ClipboardThread::spawn(transfer_tx, owner_tx, ready_tx, key.clone()) {
+        Ok(thread) => thread,
+        Err(error) => {
+            tracing::error!(%key, %error, "failed to spawn clipboard worker");
+            return false;
+        }
+    };
+    match tokio::time::timeout(INIT_TIMEOUT, ready_rx).await {
+        Ok(Ok(Ok(()))) => {}
+        Ok(Ok(Err(error))) => {
+            tracing::error!(%key, %error, "clipboard init failed");
+            return false;
+        }
+        Ok(Err(error)) => {
+            tracing::error!(%key, %error, "clipboard worker died during init");
+            return false;
+        }
+        Err(_) => {
+            // A compositor blocked forever in setup leaks this detached worker thread.
+            tracing::error!(%key, "clipboard worker init timed out");
+            return false;
+        }
+    }
+
+    let sessions_guard = SESSIONS.lock().await;
+    if !sessions_guard
+        .iter()
+        .any(|session| session.handle_path == key)
+    {
+        drop(thread);
+        return false;
+    }
+    let mut clipboard_sessions = CLIPBOARD_SESSION.lock().await;
+    if thread.exit_rx.has_changed().is_err() {
+        tracing::error!(%key, "clipboard worker died before registration");
+        return false;
+    }
+
+    let emitter = match SignalEmitter::new(&connection, "/org/freedesktop/portal/desktop") {
+        Ok(emitter) => emitter.into_owned(),
+        Err(error) => {
+            tracing::error!(%key, %error, "cannot build clipboard signal emitter");
+            return false;
+        }
+    };
+    // a displaced entry (double Start called directly at the impl) is stopped by its Drop
+    clipboard_sessions.insert(
+        key,
+        ClipboardEntry {
+            thread,
+            forwarder: Some(ForwarderParts {
+                emitter,
+                transfer_rx,
+                owner_rx,
+            }),
+        },
+    );
+    true
+}
+
+pub(crate) async fn remove_clipboard_session(object_path: ObjectPath<'_>) {
+    let mut sessions = CLIPBOARD_SESSION.lock().await;
+    if sessions.remove(&object_path).is_some() {
+        tracing::info!(%object_path, "clipboard session removal initiated");
+    }
+}
+
+/// Starts forwarding once the Start reply is on the bus; the first iteration announces
+/// the pre-existing owner state. No-op if already spawned or the session is gone.
+pub(crate) async fn spawn_clipboard_forwarder(key: &OwnedObjectPath) {
+    let mut sessions = CLIPBOARD_SESSION.lock().await;
+    let Some(entry) = sessions.get_mut(key) else {
+        return;
+    };
+    let Some(parts) = entry.forwarder.take() else {
+        return;
+    };
+    let exit_rx = entry.thread.exit_rx.clone();
+    tokio::spawn(forward_clipboard_signals(
+        parts.emitter,
+        key.clone(),
+        parts.transfer_rx,
+        parts.owner_rx,
+        exit_rx,
+    ));
+}
+
+async fn watch_closed(receiver: &mut watch::Receiver<()>) {
+    while receiver.changed().await.is_ok() {}
+}
+
+async fn forward_clipboard_signals(
+    emitter: SignalEmitter<'static>,
+    session_handle: OwnedObjectPath,
+    mut transfer_rx: mpsc::Receiver<TransferEvent>,
+    mut owner_rx: watch::Receiver<Option<OwnerState>>,
+    mut exit_rx: watch::Receiver<()>,
+) {
+    loop {
+        if exit_rx.has_changed().is_err() {
+            break;
+        }
+        tokio::select! {
+            _ = watch_closed(&mut exit_rx) => break,
+            changed = owner_rx.changed() => {
+                if changed.is_err() {
+                    break;
+                }
+                let Some(state) = owner_rx.borrow_and_update().clone() else {
+                    continue;
+                };
+                if let Err(error) = Clipboard::selection_owner_changed(
+                    &emitter,
+                    session_handle.as_ref().clone(),
+                    SelectionOwnerChangedOptions {
+                        mime_types: state.mime_types,
+                        session_is_owner: state.session_is_owner,
+                    },
+                ).await {
+                    // A failed bus emission is dropped; the shared portal connection is broken.
+                    tracing::warn!(%error, "failed to emit SelectionOwnerChanged");
+                }
+            }
+            maybe = transfer_rx.recv() => {
+                let Some(TransferEvent { mime_type, serial }) = maybe else {
+                    break;
+                };
+                if let Err(error) = Clipboard::selection_transfer(
+                    &emitter,
+                    session_handle.as_ref().clone(),
+                    &mime_type,
+                    serial,
+                ).await {
+                    // The failed signal pins this bounded transfer slot until teardown.
+                    tracing::warn!(serial, %error, "failed to emit SelectionTransfer");
+                }
+            }
+        }
+    }
 }

--- a/src/clipboard/wayland_backend.rs
+++ b/src/clipboard/wayland_backend.rs
@@ -1,133 +1,250 @@
 use std::{
     collections::HashMap,
-    os::fd::{AsFd, AsRawFd, OwnedFd},
-};
-
-use calloop_wayland_source::WaylandSource;
-use sctk::registry::{ProvidesRegistryState, RegistryState};
-use wayland_protocols::ext::data_control::v1::client::{
-    ext_data_control_device_v1::{self, ExtDataControlDeviceV1},
-    ext_data_control_manager_v1::ExtDataControlManagerV1,
-    ext_data_control_offer_v1::{self, ExtDataControlOfferV1},
-    ext_data_control_source_v1,
+    io,
+    os::fd::{AsFd, OwnedFd},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicU32, Ordering},
+    },
 };
 
 use calloop::{
     EventLoop,
-    channel::{self, Channel, Sender},
+    channel::{self, Channel, SyncSender},
 };
-use tokio::sync::oneshot::Sender as OneSender;
+use calloop_wayland_source::WaylandSource;
+use os_pipe::pipe;
+use sctk::registry::{ProvidesRegistryState, RegistryState};
+use tokio::sync::{mpsc::Sender as SignalSender, oneshot::Sender as OneSender, watch};
 use wayland_client::{
-    Connection, Dispatch, QueueHandle, delegate_noop, event_created_child,
-    globals::registry_queue_init, protocol::wl_seat::WlSeat,
+    Connection, Dispatch, Proxy, QueueHandle, backend::ObjectId, delegate_noop,
+    event_created_child, globals::registry_queue_init, protocol::wl_seat::WlSeat,
 };
+use wayland_protocols::ext::data_control::v1::client::{
+    ext_data_control_device_v1::{self, ExtDataControlDeviceV1},
+    ext_data_control_manager_v1::ExtDataControlManagerV1,
+    ext_data_control_offer_v1::{self, ExtDataControlOfferV1},
+    ext_data_control_source_v1::{self, ExtDataControlSourceV1},
+};
+use zbus::zvariant::OwnedObjectPath;
 
-use os_pipe::{PipeReader, pipe};
+static CLIPBOARD_SERIAL: AtomicU32 = AtomicU32::new(1);
 
-pub struct ClipboardThread {
-    pub sender: Sender<ClipboardRequest>,
+// caps fds pinned by clients that never call SelectionWriteDone
+const MAX_PENDING_TRANSFERS: usize = 16;
+// bounds queued commands against a stalled worker; try_send surfaces Full as a D-Bus error
+const REQUEST_QUEUE_DEPTH: usize = 64;
+
+pub(super) struct TransferEvent {
+    pub(super) mime_type: String,
+    pub(super) serial: u32,
+}
+
+#[derive(Clone)]
+pub(super) struct OwnerState {
+    pub(super) mime_types: Vec<String>,
+    pub(super) session_is_owner: bool,
+}
+
+pub(super) enum ClipboardRequest {
+    SetSelection {
+        mime_types: Vec<String>,
+    },
+    Write {
+        serial: u32,
+        sender: OneSender<Result<OwnedFd, String>>,
+    },
+    WriteDone {
+        serial: u32,
+        success: bool,
+        sender: OneSender<Result<(), String>>,
+    },
+    Read {
+        mime_type: String,
+        sender: OneSender<Result<OwnedFd, String>>,
+    },
+    Stop,
+}
+
+pub(super) struct ClipboardThread {
+    pub(super) sender: SyncSender<ClipboardRequest>,
+    pub(super) shutdown: Arc<AtomicBool>,
+    pub(super) exit_rx: watch::Receiver<()>,
 }
 
 impl ClipboardThread {
-    pub fn new() -> Self {
-        let (sender, receiver) = channel::channel();
-        std::thread::spawn(move || {
-            let _ = clipboard_loop(receiver);
-        });
-        Self { sender }
-    }
+    pub(super) fn spawn(
+        transfer_tx: SignalSender<TransferEvent>,
+        owner_tx: watch::Sender<Option<OwnerState>>,
+        ready_tx: tokio::sync::oneshot::Sender<Result<(), String>>,
+        session_path: OwnedObjectPath,
+    ) -> io::Result<Self> {
+        let (sender, receiver) = channel::sync_channel(REQUEST_QUEUE_DEPTH);
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let worker_shutdown = shutdown.clone();
+        let (exit_tx, exit_rx) = watch::channel(());
+        let log_path = session_path.clone();
 
-    pub fn stop(&self) {
-        let _ = self.sender.send(ClipboardRequest::Stop);
+        std::thread::Builder::new()
+            .name("luminous-clipboard".to_owned())
+            .spawn(move || {
+                if let Err(error) = clipboard_loop(
+                    transfer_tx,
+                    owner_tx,
+                    ready_tx,
+                    exit_tx,
+                    receiver,
+                    worker_shutdown,
+                    session_path,
+                ) {
+                    tracing::error!(%log_path, %error, "clipboard worker failed");
+                }
+                tracing::info!(%log_path, "clipboard worker exited");
+            })?;
+
+        Ok(Self {
+            sender,
+            shutdown,
+            exit_rx,
+        })
     }
 }
 
-pub struct ClipboardWl {
+impl Drop for ClipboardThread {
+    fn drop(&mut self) {
+        // NOTE: never block here (runs inside Session.Close); the flag alone stops the worker
+        self.shutdown.store(true, Ordering::SeqCst);
+        let _ = self.sender.try_send(ClipboardRequest::Stop);
+    }
+}
+
+struct ClipboardWl {
     registry_state: RegistryState,
-    seat: WlSeat,
     data_manager: ExtDataControlManagerV1,
     device: ExtDataControlDeviceV1,
     qh: QueueHandle<Self>,
+    connection: Connection,
+    transfer_tx: SignalSender<TransferEvent>,
+    owner_tx: watch::Sender<Option<OwnerState>>,
+    loop_signal: calloop::LoopSignal,
+    defunct: bool,
+    shutdown: Arc<AtomicBool>,
+    pending_offers: HashMap<ObjectId, Vec<String>>,
     current_selection: Option<ExtDataControlOfferV1>,
+    current_mime_types: Vec<String>,
     primary_selection: Option<ExtDataControlOfferV1>,
-    piperead: Option<PipeReader>,
-    mime_types: Vec<String>,
-    write_data: HashMap<i32, ClipboardData>,
+    own_source: Option<ExtDataControlSourceV1>,
+    is_owner: bool,
+    pending_writes: HashMap<u32, OwnedFd>,
 }
 
-struct ClipboardData {
-    sender: OneSender<(OwnedFd, String)>,
-    #[allow(unused)]
-    serial: u32,
-}
-
-impl Dispatch<ext_data_control_device_v1::ExtDataControlDeviceV1, ()> for ClipboardWl {
+impl Dispatch<ExtDataControlDeviceV1, ()> for ClipboardWl {
     fn event(
         state: &mut Self,
-        _proxy: &ext_data_control_device_v1::ExtDataControlDeviceV1,
-        event: <ext_data_control_device_v1::ExtDataControlDeviceV1 as wayland_client::Proxy>::Event,
+        _proxy: &ExtDataControlDeviceV1,
+        event: ext_data_control_device_v1::Event,
         _data: &(),
-        _conn: &wayland_client::Connection,
-        _qhandle: &wayland_client::QueueHandle<Self>,
+        _conn: &Connection,
+        _qhandle: &QueueHandle<Self>,
     ) {
         match event {
-            ext_data_control_device_v1::Event::DataOffer { .. } => {}
-            ext_data_control_device_v1::Event::Finished => {
-                state.reset_offer();
-                state.reset_data_device();
+            ext_data_control_device_v1::Event::DataOffer { id } => {
+                state.pending_offers.insert(id.id(), Vec::new());
             }
             ext_data_control_device_v1::Event::Selection { id } => {
-                if let Some(offer) = id {
-                    state.current_selection = Some(offer);
+                if let Some(old) = state.current_selection.take() {
+                    state.pending_offers.remove(&old.id());
+                    old.destroy();
                 }
+                let mime_types = match &id {
+                    Some(offer) => state.pending_offers.remove(&offer.id()).unwrap_or_default(),
+                    None => Vec::new(),
+                };
+                state.current_mime_types = mime_types.clone();
+                state.current_selection = id;
+                state.owner_tx.send_replace(Some(OwnerState {
+                    mime_types,
+                    session_is_owner: state.is_owner,
+                }));
             }
             ext_data_control_device_v1::Event::PrimarySelection { id } => {
-                // NOTE: we need to manager its lifetime
+                if let Some(offer) = &id {
+                    state.pending_offers.remove(&offer.id());
+                }
                 state.reset_primary_offer(id);
+            }
+            ext_data_control_device_v1::Event::Finished => {
+                tracing::error!("ext_data_control device finished; stopping clipboard worker");
+                state.defunct = true;
+                state.reset_offer();
+                state.loop_signal.stop();
             }
             _ => unreachable!(),
         }
     }
-    event_created_child!(ClipboardWl, ext_data_control_device_v1::ExtDataControlDeviceV1, [
-        ext_data_control_device_v1::EVT_DATA_OFFER_OPCODE => (ext_data_control_offer_v1::ExtDataControlOfferV1, ())
+
+    event_created_child!(ClipboardWl, ExtDataControlDeviceV1, [
+        ext_data_control_device_v1::EVT_DATA_OFFER_OPCODE => (ExtDataControlOfferV1, ())
     ]);
 }
 
-impl Dispatch<ext_data_control_source_v1::ExtDataControlSourceV1, ()> for ClipboardWl {
+impl Dispatch<ExtDataControlSourceV1, ()> for ClipboardWl {
     fn event(
         state: &mut Self,
-        _proxy: &ext_data_control_source_v1::ExtDataControlSourceV1,
-        event: <ext_data_control_source_v1::ExtDataControlSourceV1 as wayland_client::Proxy>::Event,
+        proxy: &ExtDataControlSourceV1,
+        event: ext_data_control_source_v1::Event,
         _data: &(),
-        _conn: &wayland_client::Connection,
-        _qhandle: &wayland_client::QueueHandle<Self>,
+        _conn: &Connection,
+        _qhandle: &QueueHandle<Self>,
     ) {
         match event {
             ext_data_control_source_v1::Event::Send { mime_type, fd } => {
-                let raw_fd = fd.as_raw_fd();
-                let Some(data) = state.write_data.remove(&raw_fd) else {
+                if state.pending_writes.len() >= MAX_PENDING_TRANSFERS {
+                    tracing::warn!(
+                        "pending clipboard transfers at capacity; rejecting paste request"
+                    );
                     return;
-                };
-                let _ = data.sender.send((fd, mime_type));
+                }
+                let serial = CLIPBOARD_SERIAL.fetch_add(1, Ordering::Relaxed);
+                state.pending_writes.insert(serial, fd);
+                if state
+                    .transfer_tx
+                    .try_send(TransferEvent { mime_type, serial })
+                    .is_err()
+                {
+                    state.pending_writes.remove(&serial);
+                }
             }
             ext_data_control_source_v1::Event::Cancelled => {
-                // TODO: maybe should one request to one offer?
-                state.write_data.clear();
+                if state.own_source.as_ref().map(Proxy::id) == Some(proxy.id()) {
+                    state.own_source = None;
+                    state.is_owner = false;
+                    state.owner_tx.send_replace(Some(OwnerState {
+                        mime_types: state.current_mime_types.clone(),
+                        session_is_owner: false,
+                    }));
+                }
+                proxy.destroy();
             }
             _ => unreachable!(),
         }
     }
 }
 
-impl Dispatch<ext_data_control_offer_v1::ExtDataControlOfferV1, ()> for ClipboardWl {
+impl Dispatch<ExtDataControlOfferV1, ()> for ClipboardWl {
     fn event(
-        _state: &mut Self,
-        _proxy: &ext_data_control_offer_v1::ExtDataControlOfferV1,
-        _event: <ext_data_control_offer_v1::ExtDataControlOfferV1 as wayland_client::Proxy>::Event,
+        state: &mut Self,
+        proxy: &ExtDataControlOfferV1,
+        event: ext_data_control_offer_v1::Event,
         _data: &(),
-        _conn: &wayland_client::Connection,
-        _qhandle: &wayland_client::QueueHandle<Self>,
+        _conn: &Connection,
+        _qhandle: &QueueHandle<Self>,
     ) {
+        if let ext_data_control_offer_v1::Event::Offer { mime_type } = event
+            && let Some(mimes) = state.pending_offers.get_mut(&proxy.id())
+        {
+            mimes.push(mime_type);
+        }
     }
 }
 
@@ -135,6 +252,7 @@ impl ProvidesRegistryState for ClipboardWl {
     fn registry(&mut self) -> &mut RegistryState {
         &mut self.registry_state
     }
+
     sctk::registry_handlers![];
 }
 
@@ -142,126 +260,195 @@ delegate_noop!(ClipboardWl: ignore WlSeat);
 delegate_noop!(ClipboardWl: ignore ExtDataControlManagerV1);
 sctk::delegate_registry!(ClipboardWl);
 
-pub enum ClipboardRequest {
-    SetSelection {
-        mime_types: Vec<String>,
-    },
-    Write {
-        sender: OneSender<(OwnedFd, String)>,
-        serial: u32,
-    },
-
-    Read {
-        sender: OneSender<OwnedFd>,
-        mime_type: String,
-    },
-    Stop,
-}
-
 impl ClipboardWl {
-    fn reset_data_device(&mut self) {
-        self.device.destroy();
-        self.device = self.data_manager.get_data_device(&self.seat, &self.qh, ());
-    }
     fn reset_offer(&mut self) {
         if let Some(offer) = self.current_selection.take() {
-            offer.destroy()
+            offer.destroy();
         }
+        self.current_mime_types.clear();
     }
-    fn reset_primary_offer(&mut self, id: Option<ExtDataControlOfferV1>) {
-        if let Some(id) = id {
-            if let Some(offer) = self.primary_selection.take() {
-                offer.destroy()
-            }
-            self.primary_selection = Some(id);
-        }
-    }
-    pub fn select_selection(&mut self, mime_types: Vec<String>) -> anyhow::Result<()> {
-        self.mime_types = mime_types.clone();
-        self.reset_data_device();
-        let source = self.data_manager.create_data_source(&self.qh, ());
 
-        for mime_type in mime_types {
-            source.offer(mime_type);
+    fn reset_primary_offer(&mut self, id: Option<ExtDataControlOfferV1>) {
+        if let Some(offer) = self.primary_selection.take() {
+            offer.destroy();
         }
-        self.device.set_selection(Some(&source));
-        Ok(())
+        self.primary_selection = id;
+    }
+
+    fn set_selection(&mut self, mime_types: Vec<String>) {
+        if mime_types.is_empty() {
+            self.device.set_selection(None);
+            self.own_source = None;
+            self.is_owner = false;
+            self.owner_tx.send_replace(Some(OwnerState {
+                mime_types: Vec::new(),
+                session_is_owner: false,
+            }));
+        } else {
+            let source = self.data_manager.create_data_source(&self.qh, ());
+            for mime_type in &mime_types {
+                source.offer(mime_type.clone());
+            }
+            self.device.set_selection(Some(&source));
+            self.own_source = Some(source);
+            self.is_owner = true;
+        }
+        let _ = self.connection.flush();
+    }
+
+    fn read_selection(&mut self, mime_type: &str) -> Result<OwnedFd, String> {
+        let (read, write) = pipe().map_err(|error| format!("pipe failed: {error}"))?;
+        let offer = self.current_selection.as_ref().filter(|_| {
+            self.current_mime_types
+                .iter()
+                .any(|offered| offered == mime_type)
+        });
+        if let Some(offer) = offer {
+            offer.receive(mime_type.to_owned(), write.as_fd());
+            let _ = self.connection.flush();
+        }
+        drop(write);
+        Ok(read.into())
     }
 }
-pub fn clipboard_loop(receiver: Channel<ClipboardRequest>) -> anyhow::Result<()> {
-    let connection = Connection::connect_to_env()?;
-    let (globals, event_queue) = registry_queue_init::<ClipboardWl>(&connection)?;
+
+fn handle_request(
+    app_state: &mut ClipboardWl,
+    signal: &calloop::LoopSignal,
+    message: ClipboardRequest,
+) {
+    if app_state.shutdown.load(Ordering::SeqCst) || app_state.defunct {
+        signal.stop();
+        return;
+    }
+
+    match message {
+        ClipboardRequest::SetSelection { mime_types } => {
+            app_state.set_selection(mime_types);
+        }
+        ClipboardRequest::Read { mime_type, sender } => {
+            let result = app_state.read_selection(&mime_type);
+            let _ = sender.send(result);
+        }
+        ClipboardRequest::Write { serial, sender } => {
+            let result = match app_state.pending_writes.get(&serial) {
+                Some(fd) => fd
+                    .try_clone()
+                    .map_err(|error| format!("dup failed: {error}")),
+                None => Err(format!("no pending transfer with serial {serial}")),
+            };
+            let _ = sender.send(result);
+        }
+        ClipboardRequest::WriteDone {
+            serial,
+            success,
+            sender,
+        } => {
+            tracing::debug!(serial, success, "selection write done");
+            let result = match app_state.pending_writes.remove(&serial) {
+                Some(_) => Ok(()),
+                None => Err(format!("no pending transfer with serial {serial}")),
+            };
+            let _ = sender.send(result);
+        }
+        ClipboardRequest::Stop => {
+            app_state.defunct = true;
+            signal.stop();
+        }
+    }
+}
+
+fn clipboard_loop(
+    transfer_tx: SignalSender<TransferEvent>,
+    owner_tx: watch::Sender<Option<OwnerState>>,
+    ready_tx: tokio::sync::oneshot::Sender<Result<(), String>>,
+    exit_tx: watch::Sender<()>,
+    receiver: Channel<ClipboardRequest>,
+    shutdown: Arc<AtomicBool>,
+    session_path: OwnedObjectPath,
+) -> anyhow::Result<()> {
+    tracing::debug!(%session_path, "initializing clipboard worker");
+
+    macro_rules! ready_try {
+        ($expression:expr) => {
+            match $expression {
+                Ok(value) => value,
+                Err(error) => {
+                    let message = error.to_string();
+                    let _ = ready_tx.send(Err(message.clone()));
+                    return Err(anyhow::anyhow!(message));
+                }
+            }
+        };
+    }
+
+    let connection = ready_try!(Connection::connect_to_env());
+    let (globals, mut event_queue) = ready_try!(registry_queue_init::<ClipboardWl>(&connection));
     let qh = event_queue.handle();
-    let seat = globals.bind::<WlSeat, _, _>(&qh, 1..=1, ())?;
-    let data_manager = globals.bind::<ExtDataControlManagerV1, _, _>(&qh, 1..=1, ())?;
+    let seat = ready_try!(globals.bind::<WlSeat, _, _>(&qh, 1..=1, ()));
+    let data_manager = ready_try!(globals.bind::<ExtDataControlManagerV1, _, _>(&qh, 1..=1, ()));
     let device = data_manager.get_data_device(&seat, &qh, ());
-    let mut clipbard = ClipboardWl {
+    let mut event_loop: EventLoop<ClipboardWl> = ready_try!(EventLoop::try_new());
+    let loop_signal = event_loop.get_signal();
+    let mut clipboard = ClipboardWl {
         registry_state: RegistryState::new(&globals),
-        seat,
         data_manager,
         device,
         qh,
+        connection: connection.clone(),
+        transfer_tx,
+        owner_tx,
+        loop_signal,
+        defunct: false,
+        shutdown,
+        pending_offers: HashMap::new(),
         current_selection: None,
+        current_mime_types: Vec::new(),
         primary_selection: None,
-        piperead: None,
-        mime_types: Vec::new(),
-        write_data: HashMap::new(),
+        own_source: None,
+        is_owner: false,
+        pending_writes: HashMap::new(),
     };
+    // Rebinding after `clipboard` makes the exit signal drop first during unwinding.
+    let exit_tx = exit_tx;
 
-    let mut event_loop: EventLoop<ClipboardWl> =
-        EventLoop::try_new().expect("Failed to initialize the event loop");
+    ready_try!(event_queue.roundtrip(&mut clipboard));
+    if clipboard.defunct {
+        let message = "ext_data_control device finished during initialization".to_owned();
+        let _ = ready_tx.send(Err(message.clone()));
+        return Err(anyhow::anyhow!(message));
+    }
 
-    let signal = event_loop.get_signal();
-    WaylandSource::new(connection, event_queue)
-        .insert(event_loop.handle())
-        .expect("Failed to init wayland source");
-    event_loop
-        .handle()
-        .insert_source(receiver, move |event, _, app_state| {
-            let channel::Event::Msg(message) = event else {
-                return;
-            };
+    ready_try!(WaylandSource::new(connection.clone(), event_queue).insert(event_loop.handle()));
 
-            match message {
-                ClipboardRequest::SetSelection { mime_types } => {
-                    let _ = app_state.select_selection(mime_types);
-                }
-                ClipboardRequest::Read { sender, mime_type } => {
-                    let Some(offer) = &app_state.current_selection else {
+    let request_signal = event_loop.get_signal();
+    ready_try!(
+        event_loop
+            .handle()
+            .insert_source(receiver, move |event, _, app_state| {
+                let message = match event {
+                    channel::Event::Msg(message) => message,
+                    channel::Event::Closed => {
+                        request_signal.stop();
                         return;
-                    };
-                    let (read, write) = pipe().unwrap();
-
-                    offer.receive(mime_type, write.as_fd());
-                    let _ = sender.send(read.into());
-                }
-                ClipboardRequest::Write { sender, serial } => {
-                    let Some(offer) = &app_state.current_selection else {
-                        return;
-                    };
-
-                    let (read, write) = pipe().unwrap();
-                    for mime_type in &app_state.mime_types {
-                        offer.receive(mime_type.clone(), write.as_fd());
                     }
-                    let raw_fd = write.as_raw_fd();
-                    app_state.piperead = Some(read);
-                    app_state
-                        .write_data
-                        .insert(raw_fd, ClipboardData { sender, serial });
-                }
-                ClipboardRequest::Stop => {
-                    signal.stop();
-                }
+                };
+                handle_request(app_state, &request_signal, message);
+            })
+    );
+
+    let _ = ready_tx.send(Ok(()));
+
+    let result = event_loop.run(
+        std::time::Duration::from_millis(20),
+        &mut clipboard,
+        |state| {
+            if state.shutdown.load(Ordering::SeqCst) || state.defunct {
+                state.loop_signal.stop();
             }
-        })
-        .expect("Error during event loop");
-    event_loop
-        .run(
-            std::time::Duration::from_millis(20),
-            &mut clipbard,
-            |_data| {},
-        )
-        .expect("Error during event loop");
+        },
+    );
+    drop(exit_tx);
+    result?;
     Ok(())
 }

--- a/src/input_capture.rs
+++ b/src/input_capture.rs
@@ -170,7 +170,7 @@ impl InputCapture {
                 },
             )
             .await?;
-        let current_session = Session::new(session_handle.clone(), SessionType::Remote);
+        let current_session = Session::new(session_handle.clone(), SessionType::InputCapture);
         append_session(current_session.clone()).await;
         server.at(session_handle.clone(), current_session).await?;
 

--- a/src/remotedesktop.rs
+++ b/src/remotedesktop.rs
@@ -20,11 +20,11 @@ use rustix::fd::AsFd;
 use rustix::io;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
-use zbus::interface;
 use zbus::zvariant::{
-    Fd, ObjectPath, OwnedValue, Type, Value,
+    Fd, ObjectPath, OwnedObjectPath, OwnedValue, Type, Value,
     as_value::{self, optional},
 };
+use zbus::{interface, object_server::ResponseDispatchNotifier};
 
 use crate::PortalResponse;
 use crate::input_capture::BarrierInfo;
@@ -110,6 +110,26 @@ struct RemoteStartReturnValue {
     clipboard_enabled: bool,
     #[serde(with = "as_value")]
     screen_share_enabled: bool,
+}
+
+fn remote_start_response(
+    session_handle: &ObjectPath<'_>,
+    value: RemoteStartReturnValue,
+) -> ResponseDispatchNotifier<PortalResponse<RemoteStartReturnValue>> {
+    let clipboard_enabled = value.clipboard_enabled;
+    let (response, listener) = ResponseDispatchNotifier::new(PortalResponse::Success(value));
+    if clipboard_enabled {
+        let key: OwnedObjectPath = session_handle.to_owned().into();
+        tokio::spawn(async move {
+            listener.await; // resolves once the Start reply is on the bus
+            crate::clipboard::spawn_clipboard_forwarder(&key).await;
+        });
+    }
+    response
+}
+
+fn remote_start_other() -> ResponseDispatchNotifier<PortalResponse<RemoteStartReturnValue>> {
+    ResponseDispatchNotifier::new(PortalResponse::Other).0
 }
 
 #[derive(Type, Debug, Default, Deserialize, Serialize)]
@@ -417,21 +437,23 @@ impl RemoteDesktopBackend {
         _app_id: String,
         _parent_window: String,
         _options: HashMap<String, Value<'_>>,
-    ) -> zbus::fdo::Result<PortalResponse<RemoteStartReturnValue>> {
+        #[zbus(connection)] dbus_connection: &zbus::Connection,
+    ) -> zbus::fdo::Result<ResponseDispatchNotifier<PortalResponse<RemoteStartReturnValue>>> {
         let locked_sessions = SESSIONS.lock().await;
         let Some(index) = locked_sessions
             .iter()
             .position(|this_session| this_session.handle_path == session_handle.clone().into())
         else {
             tracing::warn!("No session is created or it is removed");
-            return Ok(PortalResponse::Other);
+            return Ok(remote_start_other());
         };
 
         let current_session = locked_sessions[index].clone();
         if current_session.session_type != SessionType::Remote {
-            return Ok(PortalResponse::Other);
+            return Ok(remote_start_other());
         }
         let device_type = current_session.device_type;
+        let clipboard_requested = current_session.clipboard_requested;
         drop(locked_sessions);
 
         let remote_sessions = REMOTE_SESSIONS.lock().await;
@@ -439,11 +461,23 @@ impl RemoteDesktopBackend {
             .iter()
             .find(|session| session.session_handle == session_handle.to_string())
         {
-            return Ok(PortalResponse::Success(RemoteStartReturnValue {
-                streams: session.streams(),
-                devices: device_type,
-                ..Default::default()
-            }));
+            let streams = session.streams();
+            drop(remote_sessions);
+            let clipboard_enabled = clipboard_requested
+                && crate::clipboard::ensure_clipboard_session(
+                    &session_handle,
+                    dbus_connection.clone(),
+                )
+                .await;
+            return Ok(remote_start_response(
+                &session_handle,
+                RemoteStartReturnValue {
+                    streams,
+                    devices: device_type,
+                    clipboard_enabled,
+                    screen_share_enabled: current_session.screen_share_enabled,
+                },
+            ));
         }
         drop(remote_sessions);
 
@@ -495,12 +529,18 @@ impl RemoteDesktopBackend {
             }],
         ))
         .await;
-        Ok(PortalResponse::Success(RemoteStartReturnValue {
-            streams,
-            devices: device_type,
-            screen_share_enabled,
-            ..Default::default()
-        }))
+        let clipboard_enabled = clipboard_requested
+            && crate::clipboard::ensure_clipboard_session(&session_handle, dbus_connection.clone())
+                .await;
+        Ok(remote_start_response(
+            &session_handle,
+            RemoteStartReturnValue {
+                streams,
+                devices: device_type,
+                clipboard_enabled,
+                screen_share_enabled,
+            },
+        ))
     }
 
     // keyboard and else

--- a/src/remotedesktop.rs
+++ b/src/remotedesktop.rs
@@ -636,6 +636,7 @@ impl RemoteDesktopBackend {
     fn connect_to_eis(
         &self,
         session_handle: ObjectPath<'_>,
+        _app_id: String,
         _options: HashMap<String, Value<'_>>,
     ) -> zbus::fdo::Result<Fd<'_>> {
         let listener = eis::Listener::bind_auto()

--- a/src/session.rs
+++ b/src/session.rs
@@ -91,7 +91,7 @@ impl CursorMode {
 pub enum SessionType {
     ScreenCast,
     Remote,
-    Clipboard,
+    InputCapture,
 }
 
 #[derive(Default, Serialize, Deserialize, PartialEq, Eq, Debug, Copy, Clone, Type)]
@@ -119,6 +119,7 @@ pub struct Session {
 
     pub device_type: BitFlags<DeviceType>,
     pub screen_share_enabled: bool,
+    pub clipboard_requested: bool,
 }
 
 impl Session {
@@ -132,6 +133,7 @@ impl Session {
             persist_mode: PersistMode::DoNot,
             device_type: DeviceType::Keyboard.into(),
             screen_share_enabled: false,
+            clipboard_requested: false,
         }
     }
     pub fn set_screencast_options(&mut self, options: SelectSourcesOptions) {


### PR DESCRIPTION
Tested from my mac-> linux and linux -> mac with deskflow. Build Deskflow from master. Latest release does not have clipboard portal support. Also libportal >= 0.10 is necessary. With libportal 0.9.1, it builds without clipboard support.