### PR TITLE
Send EIS Keymap

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -205,10 +205,11 @@ pub async fn backend(
     });
 
     let receiver = remotedesktop::get_input_receiver();
+    let runtime = tokio::runtime::Handle::current();
     std::thread::spawn(move || {
         loop {
             let event = receiver.lock().unwrap().recv().unwrap();
-            tokio::spawn(remotedesktop::handle_input_event(event));
+            runtime.block_on(remotedesktop::handle_input_event(event));
         }
     });
 

--- a/src/remotedesktop/eis_server.rs
+++ b/src/remotedesktop/eis_server.rs
@@ -11,10 +11,13 @@ use reis::{
 use std::{
     collections::HashMap,
     io,
+    os::fd::AsFd,
     sync::mpsc::{self, Receiver},
     thread,
     time::Duration,
 };
+
+use super::dispatch::{get_keymap_as_file, init_xkb_objects};
 
 #[derive(Default)]
 struct ContextState {
@@ -46,7 +49,7 @@ impl ContextState {
                     self.device_keyboard = Some(add_device(
                         "keyboard",
                         BitFlags::from_flag(DeviceCapability::Keyboard),
-                        |_| {},
+                        advertise_keyboard_keymap,
                         &request.seat,
                         connection,
                         &mut self.sequence,
@@ -108,6 +111,17 @@ impl ContextState {
         }
 
         calloop::PostAction::Continue
+    }
+}
+
+fn advertise_keyboard_keymap(device: &reis::request::Device) {
+    let (_, _, state) = init_xkb_objects();
+    let (file, size) = get_keymap_as_file(&state);
+
+    if let Some(keyboard) = device.interface::<eis::Keyboard>() {
+        keyboard.keymap(eis::keyboard::KeymapType::Xkb, size, file.as_fd());
+    } else {
+        tracing::error!("Keyboard device is missing its EIS keyboard interface");
     }
 }
 


### PR DESCRIPTION
1. The tokio::spawn inside a plain std::thread panics runtime, so the input forwarding thread died on the first EIS event. 
 2. ConnectToEIS was handing callers a dup of the listening socket, which no libei client can handshake on.