### PR TITLE
fix(input_capture)!: disable input capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ An alternative to xdg-desktop-portal-wlr for wlroots compositors. This project i
 1. org.freedesktop.impl.portal.ScreenCast
 1. org.freedesktop.impl.portal.ScreenShot
 1. org.freedesktop.impl.portal.Settings
-1. org.freedesktop.impl.portal.InputCapture
 1. org.freedesktop.impl.portal.Background
 1. org.freedesktop.impl.portal.Clipboard
 

--- a/misc/luminous.portal
+++ b/misc/luminous.portal
@@ -1,3 +1,3 @@
 [portal]
 DBusName=org.freedesktop.impl.portal.desktop.luminous
-Interfaces=org.freedesktop.impl.portal.Screenshot;org.freedesktop.impl.portal.ScreenCast;org.freedesktop.impl.portal.RemoteDesktop;org.freedesktop.impl.portal.InputCapture;org.freedesktop.impl.portal.Settings;org.freedesktop.impl.portal.Access;org.freedesktop.impl.portal.Background;org.freedesktop.impl.portal.Clipboard
+Interfaces=org.freedesktop.impl.portal.Screenshot;org.freedesktop.impl.portal.ScreenCast;org.freedesktop.impl.portal.RemoteDesktop;org.freedesktop.impl.portal.Settings;org.freedesktop.impl.portal.Access;org.freedesktop.impl.portal.Background;org.freedesktop.impl.portal.Clipboard

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -2,7 +2,7 @@ use crate::access::AccessBackend;
 use crate::background::{BackgroundBackend, PendingBackgroundResponses};
 use crate::clipboard::Clipboard;
 use crate::dialog::{CopySelect, Message};
-use crate::input_capture::InputCapture;
+//use crate::input_capture::InputCapture;
 use crate::remotedesktop::RemoteDesktopBackend;
 use crate::screencast::ScreenCastBackend;
 use crate::screenshot::ScreenShotBackend;
@@ -175,7 +175,12 @@ pub async fn backend(
             RemoteDesktopBackend::default(),
         )?
         .serve_at("/org/freedesktop/portal/desktop", SettingsBackend)?
-        .serve_at("/org/freedesktop/portal/desktop", InputCapture::default())?
+        // NOTE: it is impossible to implement it just with portal. only if we are using udev, then
+        // wen cannot get the keyboard event and mouse click event. Should wait for wm to implement
+        // this part
+        // But still we can let it become the controlled part, with the ConnectToEIS on the Remote
+        // part
+        //.serve_at("/org/freedesktop/portal/desktop", InputCapture::default())?
         .serve_at("/org/freedesktop/portal/desktop", Clipboard)?
         .build()
         .await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod backend;
 mod background;
 mod clipboard;
 mod dialog;
+#[allow(unused)]
 mod input_capture;
 mod remotedesktop;
 mod request;

--- a/src/remotedesktop.rs
+++ b/src/remotedesktop.rs
@@ -62,6 +62,7 @@ pub struct ZoneId(u32);
 
 static COUNT: AtomicU32 = AtomicU32::new(0);
 
+#[allow(unused)]
 impl ZoneId {
     /// Creates a new unique window [`Id`].
     pub fn unique() -> ZoneId {
@@ -152,6 +153,7 @@ pub struct CursorPosition {
     y: f64,
 }
 
+#[allow(unused)]
 pub struct RemoteSessionData {
     pub session_handle: String,
     pub cast_thread: Option<ScreencastThread>,
@@ -181,12 +183,15 @@ impl RemoteSessionData {
             activation_id: 0,
         }
     }
+    #[allow(unused)]
     pub fn step(&mut self) {
         self.activation_id += 1;
     }
+    #[allow(unused)]
     pub fn activation_id(&self) -> u32 {
         self.activation_id
     }
+    #[allow(unused)]
     pub fn cursor_position(&self) -> CursorPosition {
         self.cursor
     }
@@ -253,12 +258,14 @@ pub async fn remove_remote_session(path: &str) {
     sessions.remove(index);
 }
 
+#[allow(unused)]
 pub async fn enable_eis_listener(session_handle: ObjectPath<'_>) {
     EIS_SERVER
         .0
         .send(EisServerMsg::ActiveListener(session_handle.to_string()))
         .unwrap();
 }
+#[allow(unused)]
 pub async fn disable_eis_listener(session_handle: ObjectPath<'_>) {
     EIS_SERVER
         .0

--- a/src/session.rs
+++ b/src/session.rs
@@ -91,6 +91,7 @@ impl CursorMode {
 pub enum SessionType {
     ScreenCast,
     Remote,
+    #[allow(unused)]
     InputCapture,
 }
 


### PR DESCRIPTION
The EIS on the input_capture side should be implemented by wm itself. only in that way we can know the keyboard event and mouse click events.

Maybe EIS should always be done by wm, using the handleshake to decide who is client and who is server, But because at least sway hasn't implemented an eis backend, it is safe to make one one the remotedesktop side.

Anyway, this implementment will never work, but it is a good learning sample, so I still kept it.

And if one day sway has made one, then it will be better to use that server directly then run one in xdg-desktop-portal